### PR TITLE
Improve user-facing documentation (README + MkDocs site)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,46 @@
 # pyramid-client-builder
 
-Introspect Pyramid views and generate a client for the app.
+[![PyPI version](https://img.shields.io/pypi/v/pyramid-client-builder.svg)](https://pypi.org/project/pyramid-client-builder/)
+[![Python versions](https://img.shields.io/pypi/pyversions/pyramid-client-builder.svg)](https://pypi.org/project/pyramid-client-builder/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
+
+Introspect a [Pyramid](https://trypyramid.com/) application and generate a typed HTTP client package — like [protoc](https://grpc.io/docs/protoc-installation/) for gRPC, but for your Pyramid REST API.
+
+## What it does
+
+`pclient-build` boots your Pyramid app from its INI file, discovers routes and [Cornice](https://cornice.readthedocs.io/) services, and writes a Python client package to disk. The generated client has one method per endpoint with natural names, Marshmallow schema serialization, and a Pyramid `includeme` for easy integration.
+
+```
+Pyramid app (INI file)
+  → introspect routes, views, schemas
+  → generate Python package
+  → client.py, schemas.py, ext.py
+```
+
+## Quick example
+
+Generate a client from your payments service:
+
+```bash
+pclient-build development.ini --name payments --output ./generated/
+```
+
+Use the generated client:
+
+```python
+from payments_client.client import PaymentsClient
+
+client = PaymentsClient(base_url="http://localhost:6543")
+
+# Methods are named from your URL paths
+charges = client.list_charges()
+charge = client.get_charge(id=42)
+new_charge = client.create_charge(amount=1000, currency="usd")
+client.cancel_charge(id=42)
+
+# Versioned APIs get sub-clients
+items = client.v1.list_items()
+```
 
 ## Installation
 
@@ -8,42 +48,45 @@ Introspect Pyramid views and generate a client for the app.
 pip install pyramid-client-builder
 ```
 
-Or with uv:
+Or with [uv](https://docs.astral.sh/uv/):
 
 ```bash
 uv add pyramid-client-builder
 ```
 
-## Usage
+## Documentation
 
-```python
-import pyramid_client_builder
-```
+Full documentation is available at the [project docs site](https://cartaorobbin.github.io/pyramid-client-builder/), including:
+
+- [Getting Started](https://cartaorobbin.github.io/pyramid-client-builder/getting-started/) — installation and first client
+- [CLI Reference](https://cartaorobbin.github.io/pyramid-client-builder/cli-reference/) — all `pclient-build` options
+- [Generated Output](https://cartaorobbin.github.io/pyramid-client-builder/generated-output/) — what files are produced
+- [Usage Guide](https://cartaorobbin.github.io/pyramid-client-builder/usage/) — standalone and Pyramid integration
+- [Features](https://cartaorobbin.github.io/pyramid-client-builder/features/) — naming, schemas, versioning
 
 ## Development
 
-### Setup
-
 ```bash
-git clone https://github.com/your-org/pyramid-client-builder.git
+git clone https://github.com/cartaorobbin/pyramid-client-builder.git
 cd pyramid-client-builder
 uv sync --dev
 ```
 
-### Run tests
+Run tests:
 
 ```bash
-uv run pytest
+uv run pytest          # single Python version
+uv run tox             # full matrix (3.10–3.13)
 ```
 
-### Lint and format
+Lint and format:
 
 ```bash
 uv run ruff check .
 uv run black .
 ```
 
-### Build docs
+Build docs locally:
 
 ```bash
 uv run mkdocs serve

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1,0 +1,95 @@
+# CLI Reference
+
+## `pclient-build`
+
+Generate an HTTP client from a Pyramid application's routes.
+
+```
+pclient-build [OPTIONS] INI_FILE
+```
+
+### Arguments
+
+| Argument | Description |
+|---|---|
+| `INI_FILE` | Path to the PasteDeploy INI configuration file (e.g., `development.ini`). The Pyramid app is bootstrapped from this file. Must exist and be readable. |
+
+### Options
+
+| Option | Required | Description |
+|---|---|---|
+| `--name TEXT` | Yes | Client name (e.g., `payments`). Used to derive the class name (`PaymentsClient`), package name (`payments_client`), request attribute (`request.payments_client`), and settings prefix (`payments.base_url`). |
+| `--output PATH` | Yes | Output directory for the generated client package. The package directory is created inside this path (e.g., `--output ./generated/` produces `./generated/payments_client/`). |
+| `--include TEXT` | No | Glob pattern to include routes. Only matching paths are generated. Can be specified multiple times. When omitted, all routes are included. |
+| `--exclude TEXT` | No | Glob pattern to exclude routes. Matching paths are removed after include filtering. Can be specified multiple times. |
+| `--debug` | No | Enable debug logging. Prints each discovered endpoint's method and path. |
+| `--version` | No | Show the installed version and exit. |
+| `--help` | No | Show the help message and exit. |
+
+### Naming conventions
+
+The `--name` option drives all generated names:
+
+| `--name` value | Class name | Package name | Request attribute | Settings prefix |
+|---|---|---|---|---|
+| `payments` | `PaymentsClient` | `payments_client` | `request.payments_client` | `payments.base_url` |
+| `user-service` | `UserServiceClient` | `user_service_client` | `request.user_service_client` | `user_service.base_url` |
+| `catalog` | `CatalogClient` | `catalog_client` | `request.catalog_client` | `catalog.base_url` |
+
+## Examples
+
+### Basic usage
+
+```bash
+pclient-build development.ini --name payments --output ./generated/
+```
+
+### Filtered generation
+
+Generate only the v1 API, excluding internal endpoints:
+
+```bash
+pclient-build production.ini --name payments --output ./clients/ \
+    --include "/api/v1/*" \
+    --exclude "/api/v1/internal/*"
+```
+
+### Multiple include patterns
+
+```bash
+pclient-build development.ini --name payments --output ./generated/ \
+    --include "/api/v1/*" \
+    --include "/api/v2/*"
+```
+
+### Debug mode
+
+See every endpoint that was discovered:
+
+```bash
+pclient-build development.ini --name payments --output ./generated/ --debug
+```
+
+```
+Bootstrapping Pyramid from development.ini
+Discovered 5 endpoints
+Generated PaymentsClient at ./generated/payments_client
+  Class:     PaymentsClient
+  Package:   payments_client
+  Request:   request.payments_client
+  Settings:  payments.base_url
+  Endpoints: 5
+    GET    /api/v1/charges
+    POST   /api/v1/charges
+    GET    /api/v1/charges/{id}
+    PUT    /api/v1/charges/{id}
+    POST   /api/v1/charges/{id}/cancel
+```
+
+## Exit codes
+
+| Code | Meaning |
+|---|---|
+| 0 | Success — client package generated |
+| 1 | No endpoints found (check your include/exclude patterns) |
+| Non-zero | Bootstrap or generation error (see stderr for details) |

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,115 @@
+# Development
+
+## Setup
+
+Clone the repository and install dependencies:
+
+```bash
+git clone https://github.com/cartaorobbin/pyramid-client-builder.git
+cd pyramid-client-builder
+uv sync --dev
+```
+
+This installs all development dependencies: ruff, black, pytest, mkdocs-material, tox, and test utilities.
+
+## Running tests
+
+### Single Python version
+
+```bash
+uv run pytest
+```
+
+### Full matrix (Python 3.10–3.13)
+
+```bash
+uv run tox
+```
+
+Tox uses `tox-uv` for fast environment creation and runs tests across all supported Python versions.
+
+### Verbose output
+
+```bash
+uv run pytest -v
+```
+
+## Linting and formatting
+
+### Check for issues
+
+```bash
+uv run ruff check .
+```
+
+### Auto-fix lint issues
+
+```bash
+uv run ruff check . --fix
+```
+
+### Format code
+
+```bash
+uv run black .
+```
+
+### Check formatting without changes
+
+```bash
+uv run black --check .
+```
+
+## Documentation
+
+### Serve locally
+
+```bash
+uv run mkdocs serve
+```
+
+Opens a local preview at `http://127.0.0.1:8000/` with live reload.
+
+### Build static site
+
+```bash
+uv run mkdocs build --strict
+```
+
+The `--strict` flag treats warnings as errors, ensuring all links and references are valid.
+
+## Project structure
+
+```
+pyramid-client-builder/
+├── src/pyramid_client_builder/    # Source code
+│   ├── cli.py                     # pclient-build Click command
+│   ├── introspection.py           # Adapter over pyramid-introspector
+│   ├── models.py                  # EndpointInfo, ClientSpec
+│   └── generator/                 # Code generation
+│       ├── core.py                # ClientGenerator orchestration
+│       ├── naming.py              # Method and schema naming
+│       ├── renderer.py            # Template tree renderer
+│       └── templates/             # Jinja2 output templates
+├── tests/
+│   ├── example_app/               # Test Pyramid app (Cornice + Marshmallow)
+│   ├── test_cli.py
+│   ├── test_generator.py
+│   └── test_introspection.py
+├── docs/                          # MkDocs documentation (this site)
+└── knowledge/                     # AI context (architecture, decisions, concepts)
+```
+
+## Architecture overview
+
+The codebase follows a three-layer pipeline:
+
+```
+Introspection → ClientSpec → Code Generation
+```
+
+- **Introspection** — boots the Pyramid app and reads its route registry via `pyramid-introspector`. The local adapter flattens routes/views into `EndpointInfo` objects and applies filtering.
+- **ClientSpec** — a plain data structure containing the client name, endpoints, and schemas. Bridges introspection and generation.
+- **Code Generation** — renders Jinja2 templates from a template tree that mirrors the output directory structure. The `@each(var)` directive handles dynamic directories (e.g., per-version subdirs).
+
+For detailed architecture documentation, see `knowledge/architecture.md` in the repository.

--- a/docs/features.md
+++ b/docs/features.md
@@ -1,0 +1,161 @@
+# Features
+
+## Method naming
+
+The generator interprets your URL path structure to produce natural Python method names. No annotations or configuration needed — names are derived automatically.
+
+### Collection endpoints
+
+Paths ending with a resource name represent collections. GET requests use the `list_` prefix:
+
+| Method | Path | Generated name |
+|---|---|---|
+| GET | `/api/v1/charges` | `list_charges()` |
+| POST | `/api/v1/charges` | `create_charge()` |
+
+### Detail endpoints
+
+Paths ending with a path parameter represent a single resource. Names are singularized:
+
+| Method | Path | Generated name |
+|---|---|---|
+| GET | `/api/v1/charges/{id}` | `get_charge()` |
+| PUT | `/api/v1/charges/{id}` | `update_charge()` |
+| DELETE | `/api/v1/charges/{id}` | `delete_charge()` |
+
+### Verb detection
+
+Paths ending with an action word use that verb as the method prefix. The generator uses NLTK WordNet to detect verbs, so `/charges/{id}/cancel` becomes `cancel_charge()` instead of the naive `create_charge_cancel()`:
+
+| Method | Path | Generated name |
+|---|---|---|
+| POST | `/api/v1/charges/{id}/cancel` | `cancel_charge()` |
+| POST | `/api/v1/charges/{id}/refund` | `refund_charge()` |
+| POST | `/api/v1/orders/{id}/approve` | `approve_order()` |
+
+### Non-API paths
+
+Routes without a clear resource structure (e.g., `/`, `/health`) fall back to the route name:
+
+| Method | Path | Route name | Generated name |
+|---|---|---|---|
+| GET | `/` | `home` | `get_home()` |
+| GET | `/health` | `health` | `get_health()` |
+
+## Schema renaming
+
+Server-side schemas are named by domain concept (e.g., `ChargeSchema`). In the generated client, schemas are renamed by their **usage role** so consumers can tell what they send from what they receive.
+
+### Role suffixes
+
+| Role | Suffix | Used for |
+|---|---|---|
+| Request body | `RequestSchema` | Serializing outgoing POST/PUT bodies |
+| Response | `ResponseSchema` | Deserializing incoming responses |
+| Querystring | `QuerySchema` | Serializing query parameters |
+| Error response | `ErrorSchema` | Error response bodies |
+
+### Renaming rules
+
+- Schemas without a role suffix are renamed based on the endpoint path and usage:
+    - `ChargeSchema` on `POST /api/v1/charges` (request) → `ChargesRequestSchema`
+    - `ChargeSchema` on `GET /api/v1/charges/{id}` (response) → `ChargeResponseSchema`
+- Schemas that already have a recognized suffix (`RequestSchema`, `ResponseSchema`, `QuerySchema`, `BodySchema`, `PathSchema`, `ErrorSchema`) are left unchanged.
+- If the same schema would get conflicting names from different endpoints, the original name is preserved.
+
+## API versioning
+
+When your endpoints have version prefixes in their paths (e.g., `/api/v1/...`, `/api/v2/...`), the generator produces a versioned output structure.
+
+### How it works
+
+1. The generator detects `v<digits>` segments in endpoint paths
+2. Endpoints are grouped by version
+3. Each version gets its own subdirectory with a dedicated client and schemas
+4. A root client aggregates version sub-clients as properties
+
+### Usage
+
+```python
+client = PaymentsClient(base_url="http://localhost:6543")
+
+# Version sub-clients
+charges_v1 = client.v1.list_charges()
+charges_v2 = client.v2.list_charges()
+
+# Unversioned endpoints stay on the root
+health = client.get_health()
+```
+
+### Benefits
+
+- Schema names can't conflict across versions (each version has its own `schemas.py`)
+- You can evolve your API without breaking the existing generated client
+- Auth configuration is shared — set it once on the root client
+
+When no versioned endpoints are detected, the flat output structure is used instead.
+
+## Include / exclude filtering
+
+Control which endpoints are generated using glob patterns:
+
+```bash
+# Only include v1 API routes
+pclient-build dev.ini --name payments --output ./gen/ \
+    --include "/api/v1/*"
+
+# Exclude internal and webhook endpoints
+pclient-build dev.ini --name payments --output ./gen/ \
+    --exclude "/api/v1/internal/*" \
+    --exclude "/api/v1/webhooks/*"
+
+# Combine both — include first, then exclude from the result
+pclient-build dev.ini --name payments --output ./gen/ \
+    --include "/api/*" \
+    --exclude "*/internal/*"
+```
+
+Patterns are matched against the endpoint's URL path using Python's `fnmatch` style:
+
+- `*` matches any sequence of characters within a single path segment
+- `?` matches any single character
+- Multiple `--include` and `--exclude` flags can be specified
+
+When `--include` is used, only matching endpoints are kept. When `--exclude` is used, matching endpoints are removed. If both are specified, include is applied first, then exclude.
+
+## Cornice and pycornmarsh support
+
+The generator works with both Cornice schema patterns:
+
+### Standard Cornice
+
+Schemas declared via the `schema` kwarg on Cornice decorators:
+
+```python
+@service.post(schema=ChargeSchema, validators=(colander_body_validator,))
+def create_charge(request):
+    ...
+```
+
+### pycornmarsh
+
+Explicit location-to-schema mapping via `pcm_request` and per-status-code response schemas via `pcm_responses`:
+
+```python
+@service.post(
+    pcm_request=dict(body=ChargeBodySchema, querystring=ChargeQuerySchema),
+    pcm_responses={200: ChargeResponseSchema, 400: ChargeErrorSchema},
+)
+def create_charge(request):
+    ...
+```
+
+When both patterns are present, `pcm_request` takes precedence for request schemas, and `pcm_responses` takes precedence for response schemas. This gives you more explicit control over the generated client's types.
+
+## Conditional file generation
+
+The generated output adapts to your API:
+
+- **`schemas.py`** is only created when endpoints have Marshmallow schemas. Plain Pyramid routes without schema declarations still produce a working client — methods return raw `response.json()`.
+- **Version subdirectories** only appear when versioned paths are detected.
+- **Files that would be empty** are skipped entirely (e.g., a version's `schemas.py` when that version has no schemas).

--- a/docs/generated-output.md
+++ b/docs/generated-output.md
@@ -1,0 +1,153 @@
+# Generated Output
+
+This page explains the structure and contents of the client package produced by `pclient-build`.
+
+## Flat output (no versioning)
+
+When your API paths don't contain version prefixes, the generator produces a flat package:
+
+```
+payments_client/
+├── __init__.py      # Package init with imports
+├── client.py        # HTTP client class
+├── ext.py           # Pyramid includeme extension
+└── schemas.py       # Marshmallow schemas (only if schemas exist)
+```
+
+## Versioned output
+
+When your endpoints have version prefixes (e.g., `/api/v1/charges`, `/api/v2/charges`), the generator creates per-version subdirectories:
+
+```
+payments_client/
+├── __init__.py
+├── client.py        # Root client with version sub-client properties
+├── ext.py
+├── schemas.py       # Schemas for unversioned endpoints (if any)
+├── v1/
+│   ├── __init__.py
+│   ├── client.py    # V1Client with v1 endpoints
+│   └── schemas.py   # Schemas for v1 endpoints
+└── v2/
+    ├── __init__.py
+    ├── client.py    # V2Client with v2 endpoints
+    └── schemas.py   # Schemas for v2 endpoints
+```
+
+## File-by-file breakdown
+
+### `client.py`
+
+The main client class. Each endpoint becomes a method:
+
+```python
+class PaymentsClient:
+    """Auto-generated HTTP client for the payments Pyramid application."""
+
+    def __init__(self, base_url, auth_token=None, timeout=30):
+        self.base_url = base_url.rstrip("/")
+        self.timeout = timeout
+        self.session = requests.Session()
+        if auth_token:
+            self.session.headers["Authorization"] = f"Bearer {auth_token}"
+        # Version sub-clients (only in versioned output)
+        self.v1 = V1Client(self.base_url, self.session, self.timeout)
+
+    def list_charges(self):
+        """GET /api/v1/charges"""
+        url = f"{self.base_url}/api/v1/charges"
+        response = self.session.get(url, timeout=self.timeout)
+        response.raise_for_status()
+        return ChargesResponseSchema().load(response.json())
+
+    def create_charge(self, amount, currency):
+        """POST /api/v1/charges"""
+        url = f"{self.base_url}/api/v1/charges"
+        body = ChargesRequestSchema().dump(
+            {"amount": amount, "currency": currency}
+        )
+        response = self.session.post(url, json=body, timeout=self.timeout)
+        response.raise_for_status()
+        return ChargeResponseSchema().load(response.json())
+```
+
+Key behaviors:
+
+- **Path parameters** become required positional arguments
+- **Body parameters** become keyword arguments, serialized through the request schema's `dump()`
+- **Querystring parameters** become optional keyword arguments
+- **Responses** are deserialized through the response schema's `load()`, or returned as raw `response.json()` when no schema exists
+- **Errors** raise via `response.raise_for_status()` (standard `requests` behavior)
+
+### `schemas.py`
+
+Copies of your server's Marshmallow schemas, renamed by role:
+
+```python
+from marshmallow import Schema, fields
+
+class ChargesRequestSchema(Schema):
+    amount = fields.Integer(required=True)
+    currency = fields.String(required=True)
+
+class ChargeResponseSchema(Schema):
+    id = fields.Integer()
+    amount = fields.Integer()
+    currency = fields.String()
+    status = fields.String()
+```
+
+This file is only generated when your endpoints have Marshmallow schemas attached. See [Features > Schema renaming](features.md#schema-renaming) for how names are derived.
+
+### `ext.py`
+
+A Pyramid extension that registers the client on the request:
+
+```python
+def includeme(config):
+    def payments_client(request):
+        return PaymentsClient(
+            base_url=request.registry.settings["payments.base_url"],
+            auth_token=request.registry.settings.get("payments.auth_token"),
+        )
+
+    config.add_request_method(
+        payments_client, name="payments_client", reify=True
+    )
+```
+
+The client is created once per request (`reify=True`) and reads its configuration from the app's INI settings.
+
+### `__init__.py`
+
+Package init that imports the client class and schemas for convenience:
+
+```python
+from payments_client.client import PaymentsClient
+from payments_client.schemas import ChargesRequestSchema, ChargeResponseSchema
+```
+
+### Version sub-client (`v1/client.py`)
+
+In versioned output, each version gets its own client class that shares the parent's session:
+
+```python
+class V1Client:
+    """Auto-generated HTTP client for payments API v1."""
+
+    def __init__(self, base_url, session, timeout):
+        self.base_url = base_url
+        self.session = session
+        self.timeout = timeout
+
+    def list_charges(self):
+        """GET /api/v1/charges"""
+        # ...
+```
+
+This means authentication is configured once on the root client and shared across all versions.
+
+## Conditional generation
+
+- **`schemas.py`** is only generated when endpoints have Marshmallow schemas. Plain Pyramid routes without Cornice/Marshmallow still produce a working client — methods just return raw `response.json()`.
+- **Version subdirectories** are only created when versioned paths are detected. If all your paths are flat, you get the simple flat layout.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,125 @@
+# Getting Started
+
+## Prerequisites
+
+- Python 3.10+
+- A Pyramid application with a PasteDeploy INI file (e.g., `development.ini`)
+- The Pyramid app must be importable (its package installed or on `PYTHONPATH`)
+
+## Installation
+
+=== "pip"
+
+    ```bash
+    pip install pyramid-client-builder
+    ```
+
+=== "uv"
+
+    ```bash
+    uv add pyramid-client-builder
+    ```
+
+`pyramid-client-builder` is a **build-time tool** — add it as a dev dependency, not a runtime one. The generated client package has its own dependencies (`requests`, and `marshmallow` when schemas are present).
+
+## Your first client
+
+### 1. Run the generator
+
+Point `pclient-build` at your Pyramid app's INI file:
+
+```bash
+pclient-build development.ini --name payments --output ./generated/
+```
+
+This will:
+
+1. Boot your Pyramid app from the INI file
+2. Discover all routes and Cornice services
+3. Generate a `payments_client` package in `./generated/`
+
+You'll see output like:
+
+```
+Bootstrapping Pyramid from development.ini
+Discovered 12 endpoints
+Generated PaymentsClient at ./generated/payments_client
+  Class:     PaymentsClient
+  Package:   payments_client
+  Request:   request.payments_client
+  Settings:  payments.base_url
+  Endpoints: 12
+```
+
+### 2. Use the generated client
+
+The generated package is a regular Python package. You can use it directly:
+
+```python
+from payments_client.client import PaymentsClient
+
+client = PaymentsClient(
+    base_url="http://localhost:6543",
+    auth_token="your-token",
+)
+
+# List all charges
+charges = client.list_charges()
+
+# Get a specific charge
+charge = client.get_charge(id=42)
+
+# Create a charge — body parameters become keyword arguments
+new_charge = client.create_charge(amount=1000, currency="usd")
+```
+
+### 3. Integrate with Pyramid (optional)
+
+If the consuming app is also a Pyramid application, you can register the client on the request object:
+
+Add to your INI file:
+
+```ini
+payments.base_url = http://payments-service:6543
+payments.auth_token = secret
+```
+
+Include the extension in your Pyramid configuration:
+
+```python
+config.include("payments_client.ext")
+```
+
+Then use it in any view:
+
+```python
+def my_view(request):
+    charges = request.payments_client.list_charges()
+    return {"charges": charges}
+```
+
+## Filtering endpoints
+
+You don't have to generate a client for every route. Use `--include` and `--exclude` to select what you need:
+
+```bash
+# Only v1 API endpoints
+pclient-build development.ini --name payments --output ./generated/ \
+    --include "/api/v1/*"
+
+# Everything except webhooks
+pclient-build development.ini --name payments --output ./generated/ \
+    --exclude "/api/v1/webhooks/*"
+
+# Combine both — patterns can be repeated
+pclient-build development.ini --name payments --output ./generated/ \
+    --include "/api/v1/*" --include "/api/v2/*" \
+    --exclude "*/internal/*"
+```
+
+## Next steps
+
+- [CLI Reference](cli-reference.md) — all `pclient-build` options in detail
+- [Generated Output](generated-output.md) — understand what files are produced
+- [Usage Guide](usage.md) — method signatures, schema handling, error patterns
+- [Features](features.md) — method naming, versioning, schema renaming

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,56 @@
 # pyramid-client-builder
 
-Introspect Pyramid views and generate a client for the app.
+Introspect a [Pyramid](https://trypyramid.com/) application and generate a typed HTTP client package — like `protoc` for gRPC, but for your Pyramid REST API.
 
-## Getting Started
+## How it works
 
-See the [README](https://github.com/your-org/pyramid-client-builder) for installation and usage instructions.
+`pyramid-client-builder` reads your Pyramid app's route and view configuration at runtime, extracts endpoint metadata (paths, methods, parameters, Marshmallow schemas), and produces a standalone Python client package.
+
+```mermaid
+flowchart LR
+    A["Pyramid App\n(INI file)"] --> B["Introspection"]
+    B --> C["ClientSpec"]
+    C --> D["Code Generation"]
+    D --> E["Client Package\n(Python source)"]
+```
+
+Each layer is independent:
+
+- **Introspection** boots the app and reads the route registry — no code generation happens here.
+- **ClientSpec** is a plain data structure describing all endpoints and schemas — it can be built manually for testing.
+- **Code Generation** reads a ClientSpec and renders Jinja2 templates — it never touches Pyramid.
+
+## What you get
+
+Running `pclient-build` produces a Python package with:
+
+- **`client.py`** — an HTTP client class with one method per endpoint, using `requests` for transport
+- **`schemas.py`** — copies of your server's Marshmallow schemas for request/response serialization
+- **`ext.py`** — a Pyramid `includeme` that registers the client on `request` (e.g., `request.payments_client`)
+- **Per-version subdirectories** — when your API has versioned paths (`/api/v1/...`), each version gets its own client and schemas
+
+## Quick start
+
+```bash
+pip install pyramid-client-builder
+
+pclient-build development.ini --name payments --output ./generated/
+```
+
+```python
+from payments_client.client import PaymentsClient
+
+client = PaymentsClient(base_url="http://localhost:6543")
+charges = client.list_charges()
+```
+
+See [Getting Started](getting-started.md) for a full walkthrough.
+
+## Features at a glance
+
+- **Natural method names** — `/charges/{id}/cancel` becomes `cancel_charge()`, not `create_charge_cancel()`
+- **Schema serialization** — request bodies are serialized with `schema.dump()`, responses deserialized with `schema.load()`
+- **API versioning** — versioned paths produce sub-clients: `client.v1.list_charges()`
+- **Include/exclude filtering** — generate only the endpoints you need with glob patterns
+- **Cornice + pycornmarsh** — supports both Cornice schema patterns out of the box
+- **Deterministic** — same inputs always produce identical output

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,166 @@
+# Usage Guide
+
+## Standalone usage
+
+The generated client works as a regular Python HTTP client with no Pyramid dependency:
+
+```python
+from payments_client.client import PaymentsClient
+
+client = PaymentsClient(
+    base_url="http://localhost:6543",
+    auth_token="your-bearer-token",
+    timeout=30,
+)
+```
+
+### Constructor parameters
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `base_url` | `str` | (required) | Base URL of the target service. Trailing slashes are stripped. |
+| `auth_token` | `str` | `None` | Bearer token added to the `Authorization` header. |
+| `timeout` | `int` | `30` | Request timeout in seconds. |
+
+### Session access
+
+The client exposes its `requests.Session` for advanced configuration:
+
+```python
+client = PaymentsClient(base_url="http://localhost:6543")
+
+# Custom headers
+client.session.headers["X-Request-ID"] = "abc-123"
+
+# Client certificates
+client.session.cert = ("/path/to/client.cert", "/path/to/client.key")
+
+# Retry logic (via requests adapters)
+from requests.adapters import HTTPAdapter
+adapter = HTTPAdapter(max_retries=3)
+client.session.mount("http://", adapter)
+```
+
+## Pyramid integration
+
+For Pyramid-to-Pyramid service calls, the generated `ext.py` provides seamless integration.
+
+### Setup
+
+1. Add settings to your INI file:
+
+    ```ini
+    # Required
+    payments.base_url = http://payments-service:6543
+
+    # Optional
+    payments.auth_token = secret-token
+    ```
+
+2. Include the extension in your app configuration:
+
+    ```python
+    def main(global_config, **settings):
+        config = Configurator(settings=settings)
+        config.include("payments_client.ext")
+        # ...
+        return config.make_wsgi_app()
+    ```
+
+3. Use it in views:
+
+    ```python
+    def checkout_view(request):
+        charge = request.payments_client.create_charge(
+            amount=1000, currency="usd"
+        )
+        return {"charge_id": charge["id"]}
+    ```
+
+The client is created once per request (`reify=True`) — multiple accesses within the same request reuse the same instance.
+
+## Method signatures
+
+Every generated method follows consistent conventions:
+
+### Path parameters → positional arguments
+
+URL path parameters become required arguments:
+
+```python
+# GET /api/v1/charges/{id}
+charge = client.get_charge(id=42)
+
+# PUT /api/v1/customers/{customer_id}/cards/{card_id}
+card = client.update_card(customer_id=1, card_id=5, last4="1234")
+```
+
+### Body parameters → keyword arguments
+
+Request body fields become keyword arguments:
+
+```python
+# POST /api/v1/charges  (body: amount, currency)
+charge = client.create_charge(amount=1000, currency="usd")
+```
+
+When a request schema exists, the arguments are passed through `schema.dump()` before being sent as JSON. This gives you the same validation and type coercion the server applies on its end.
+
+### Querystring parameters → optional keyword arguments
+
+Querystring fields become optional keyword arguments:
+
+```python
+# GET /api/v1/charges?status=pending&limit=10
+charges = client.list_charges(status="pending", limit=10)
+```
+
+`None` values are excluded from the query string.
+
+## Schema serialization
+
+When your endpoints have Marshmallow schemas, the generated client uses them for serialization:
+
+- **Outgoing requests**: `schema.dump()` serializes the body or querystring — the mirror of the server's `schema.load()`
+- **Incoming responses**: `schema.load()` deserializes the JSON response — the mirror of the server's `schema.dump()`
+
+```python
+# Under the hood, create_charge does:
+# 1. body = ChargesRequestSchema().dump({"amount": 1000, "currency": "usd"})
+# 2. response = session.post(url, json=body)
+# 3. return ChargeResponseSchema().load(response.json())
+charge = client.create_charge(amount=1000, currency="usd")
+```
+
+Endpoints without schemas fall back to raw dicts — `response.json()` is returned directly.
+
+## Error handling
+
+The generated client calls `response.raise_for_status()` on every response. This raises `requests.HTTPError` for 4xx/5xx status codes:
+
+```python
+from requests.exceptions import HTTPError
+
+try:
+    charge = client.get_charge(id=999)
+except HTTPError as e:
+    print(f"Status: {e.response.status_code}")
+    print(f"Body: {e.response.json()}")
+```
+
+## Versioned APIs
+
+When your API has versioned paths, the root client provides sub-client properties:
+
+```python
+client = PaymentsClient(base_url="http://localhost:6543")
+
+# Access version-specific endpoints
+v1_charges = client.v1.list_charges()
+v2_charges = client.v2.list_charges()
+
+# Unversioned endpoints (e.g., /health) stay on the root client
+health = client.get_health()
+```
+
+All version sub-clients share the root client's session, so authentication and other session configuration is set up once.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,39 @@
 site_name: pyramid-client-builder
+site_description: Introspect Pyramid views and generate an HTTP client for the app
+site_url: https://cartaorobbin.github.io/pyramid-client-builder/
+repo_url: https://github.com/cartaorobbin/pyramid-client-builder
+repo_name: cartaorobbin/pyramid-client-builder
+
 theme:
   name: material
+  features:
+    - content.code.copy
+    - navigation.sections
+    - navigation.expand
+    - search.suggest
+    - search.highlight
+
 nav:
   - Home: index.md
+  - Getting Started: getting-started.md
+  - CLI Reference: cli-reference.md
+  - Generated Output: generated-output.md
+  - Usage Guide: usage.md
+  - Features: features.md
+  - Development: development.md
+
+markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.tabbed:
+      alternate_style: true
+  - toc:
+      permalink: true


### PR DESCRIPTION
## Summary

- Rewrote README with real GitHub URLs, PyPI/CI badges, proper project description, CLI example, and generated client usage snippet
- Built out multi-page MkDocs site with 7 pages: overview, getting started, CLI reference, generated output guide, usage patterns, features overview, and development/contributing guide
- Updated mkdocs.yml with full navigation, repo URL, Material theme features (code copy, search, mermaid diagrams, admonitions, tabbed content)

Closes #5

## Test plan

- [x] `mkdocs build --strict` passes with no errors
- [ ] Review rendered docs locally with `mkdocs serve`
- [ ] Verify all internal page links resolve correctly
- [ ] Check code examples are accurate and consistent


Made with [Cursor](https://cursor.com)