### PR TITLE
Add pre-commit hooks, Makefile, and agent quality gate

### DIFF
--- a/.cursor/rules/pre-pr-check.mdc
+++ b/.cursor/rules/pre-pr-check.mdc
@@ -1,0 +1,16 @@
+---
+description: Run quality checks before creating pull requests
+alwaysApply: true
+---
+
+# Pre-PR Quality Check
+
+**Before creating any pull request**, you MUST:
+
+1. Run `make check` (which runs lint + tests)
+2. If it fails, fix the issues and re-run until it passes
+3. Only then proceed with the commit and PR
+
+This catches formatting (black), linting (ruff), and test failures before they reach CI.
+
+Never skip this step. Never create a PR with a failing `make check`.

--- a/.cursor/skills/dev-workflow/SKILL.md
+++ b/.cursor/skills/dev-workflow/SKILL.md
@@ -118,9 +118,19 @@ Throughout execution, keep the issue and TodoWrite aligned:
 - If the plan needs adjustment mid-execution, update both the TodoWrite list and post an updated plan comment on the issue
 - If new tasks emerge, add them to both TodoWrite and the issue
 
-## Step 7: Pull Request
+## Step 7: Quality Gate
 
-When all tasks are complete:
+Before creating the PR, run the full quality check:
+
+```bash
+make check
+```
+
+This runs lint (ruff + black) and the full test suite. If anything fails, fix the issues and re-run until it passes. **Never create a PR with a failing `make check`.**
+
+## Step 8: Pull Request
+
+When all tasks are complete and `make check` passes:
 
 1. Ensure all changes are committed
 2. Push the branch: `git push`
@@ -147,7 +157,7 @@ EOF
 
 5. Tell the user the PR is ready for review and provide the PR URL.
 
-## Step 8: Release
+## Step 9: Release
 
 > This step only applies to projects with a release flow.
 
@@ -174,7 +184,7 @@ gh release create v<version> --generate-notes --title "v<version>"
 
 4. Tell the user the release has been created and provide the URL.
 
-## Step 9: End
+## Step 10: End
 
 Summarize what was accomplished:
 - Issue number and title

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,10 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.5
+    hooks:
+      - id: ruff
+        args: [--fix]
+  - repo: https://github.com/psf/black
+    rev: "26.3.0"
+    hooks:
+      - id: black

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+.PHONY: lint fix test check
+
+lint:
+	uv run ruff check .
+	uv run black --check .
+
+fix:
+	uv run ruff check . --fix
+	uv run black .
+
+test:
+	uv run pytest
+
+check: lint test

--- a/knowledge/decisions.md
+++ b/knowledge/decisions.md
@@ -236,3 +236,15 @@ Use this format when adding a new decision:
 **Decision**: Add a `--http-client` CLI option with choices `requests` (default) and `httpx`. The `ClientGenerator` accepts an `http_client` parameter and passes it into the Jinja2 template context. Templates use `{% if http_client == "httpx" %}` conditionals to switch between `import requests` / `requests.Session()` and `import httpx` / `httpx.Client()`. The generated `pyproject.toml` declares the matching dependency (`requests>=2.28` or `httpx>=0.24`). Only synchronous httpx is supported in this iteration — `httpx.Client` is a sync drop-in for `requests.Session` with an identical method API (`.get()`, `.post()`, `.headers`, `response.raise_for_status()`, `response.json()`).
 
 **Consequences**: Users can choose their preferred HTTP library at generation time. Default behavior is unchanged (requests). The Jinja-conditional approach keeps a single template tree — no duplication. Async httpx (`httpx.AsyncClient`) can be added later as a third option. The builder itself does not depend on either library at runtime; they are only dependencies of the generated client.
+
+---
+
+### 2026-03-15 — Pre-commit hooks, Makefile, and agent quality gate
+
+**Status**: Accepted
+
+**Context**: CI caught a black formatting issue on PR #11 that could have been caught locally. There was no pre-commit hook, no convenient `make` targets, and no agent rule to enforce checks before creating PRs.
+
+**Decision**: Add three layers of quality assurance: (1) a `.pre-commit-config.yaml` with ruff (auto-fix) and black hooks that run on every commit, (2) a `Makefile` with `lint`, `fix`, `test`, and `check` targets (`make check` = lint + test, the full gate), and (3) a Cursor agent rule (`.cursor/rules/pre-pr-check.mdc`) that requires running `make check` before creating any PR. The dev-workflow skill is updated with a "Quality Gate" step between execution and PR creation.
+
+**Consequences**: Formatting and lint issues are caught at commit time (pre-commit) or at PR time (agent rule + `make check`). Developers get convenient shortcuts (`make fix`, `make check`). The agent cannot skip checks before PRs. Three layers provide defense in depth: pre-commit for devs, `make check` for the agent, and CI as the final backstop.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,4 +61,5 @@ dev = [
     "marshmallow",
     "tox",
     "tox-uv>=1.25",
+    "pre-commit",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -139,6 +139,15 @@ wheels = [
 ]
 
 [[package]]
+name = "cfgv"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/b5/721b8799b04bf9afe054a3899c6cf4e880fcf8563cc71c15610242490a0c/cfgv-3.5.0.tar.gz", hash = "sha256:d5b1034354820651caa73ede66a6294d6e95c1b00acc5e9b098e917404669132", size = 7334, upload-time = "2025-11-19T20:55:51.612Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl", hash = "sha256:a8dc6b26ad22ff227d2634a65cb388215ce6cc96bbcc5cfde7641ae87e8dacc0", size = 7445, upload-time = "2025-11-19T20:55:50.744Z" },
+]
+
+[[package]]
 name = "charset-normalizer"
 version = "3.4.5"
 source = { registry = "https://pypi.org/simple" }
@@ -309,6 +318,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/bd/e6/bb064537288eee2be97f3e0fcad8e7242bc5bbe9664ae57c7d29b3fa18c2/hupper-1.12.1.tar.gz", hash = "sha256:06bf54170ff4ecf4c84ad5f188dee3901173ab449c2608ad05b9bfd6b13e32eb", size = 43231, upload-time = "2024-01-26T09:14:57.294Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/86/7d/3888833e4f5ea56af4a9935066ec09a83228e533d7b8877f65889d706ee4/hupper-1.12.1-py3-none-any.whl", hash = "sha256:e872b959f09d90be5fb615bd2e62de89a0b57efc037bdf9637fb09cdf8552b19", size = 22830, upload-time = "2024-01-26T09:14:55.176Z" },
+]
+
+[[package]]
+name = "identify"
+version = "2.6.18"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/c4/7fb4db12296cdb11893d61c92048fe617ee853f8523b9b296ac03b43757e/identify-2.6.18.tar.gz", hash = "sha256:873ac56a5e3fd63e7438a7ecbc4d91aca692eb3fefa4534db2b7913f3fc352fd", size = 99580, upload-time = "2026-03-15T18:39:50.319Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/33/92ef41c6fad0233e41d3d84ba8e8ad18d1780f1e5d99b3c683e6d7f98b63/identify-2.6.18-py2.py3-none-any.whl", hash = "sha256:8db9d3c8ea9079db92cafb0ebf97abdc09d52e97f4dcf773a2e694048b7cd737", size = 99394, upload-time = "2026-03-15T18:39:48.915Z" },
 ]
 
 [[package]]
@@ -569,6 +587,15 @@ wheels = [
 ]
 
 [[package]]
+name = "nodeenv"
+version = "1.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.0"
 source = { registry = "https://pypi.org/simple" }
@@ -645,6 +672,22 @@ wheels = [
 ]
 
 [[package]]
+name = "pre-commit"
+version = "4.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cfgv" },
+    { name = "identify" },
+    { name = "nodeenv" },
+    { name = "pyyaml" },
+    { name = "virtualenv" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/40/f1/6d86a29246dfd2e9b6237f0b5823717f60cad94d47ddc26afa916d21f525/pre_commit-4.5.1.tar.gz", hash = "sha256:eb545fcff725875197837263e977ea257a402056661f09dae08e4b149b030a61", size = 198232, upload-time = "2025-12-16T21:14:33.552Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/19/fd3ef348460c80af7bb4669ea7926651d1f95c23ff2df18b9d24bab4f3fa/pre_commit-4.5.1-py2.py3-none-any.whl", hash = "sha256:3b3afd891e97337708c1674210f8eba659b52a38ea5f822ff142d10786221f77", size = 226437, upload-time = "2025-12-16T21:14:32.409Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.19.2"
 source = { registry = "https://pypi.org/simple" }
@@ -716,6 +759,7 @@ dev = [
     { name = "cornice" },
     { name = "marshmallow" },
     { name = "mkdocs-material" },
+    { name = "pre-commit" },
     { name = "pytest" },
     { name = "ruff" },
     { name = "tox" },
@@ -738,6 +782,7 @@ dev = [
     { name = "cornice" },
     { name = "marshmallow" },
     { name = "mkdocs-material" },
+    { name = "pre-commit" },
     { name = "pytest" },
     { name = "ruff" },
     { name = "tox" },


### PR DESCRIPTION
## Summary

- Add `.pre-commit-config.yaml` with ruff (auto-fix) and black hooks to catch lint/format issues at commit time
- Add `Makefile` with `lint`, `fix`, `test`, and `check` targets (`make check` = lint + test)
- Add `.cursor/rules/pre-pr-check.mdc` agent rule requiring `make check` before creating any PR
- Update dev-workflow skill with a Quality Gate step between execution and PR creation

Closes #12

## Test plan

- [x] `make check` passes (lint clean, 180 tests green)
- [x] `make lint` runs ruff + black --check
- [x] `make fix` runs ruff --fix + black
- [x] `make test` runs pytest
- [ ] `pre-commit install && pre-commit run --all-files` installs and runs hooks successfully