### PR TITLE
Add smoke tests for generated code

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,13 @@
+FROM mcr.microsoft.com/devcontainers/python:3.12
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends unzip \
+    && DART_ARCH=$(dpkg --print-architecture) \
+    && curl -fsSL "https://storage.googleapis.com/dart-archive/channels/stable/release/latest/sdk/dartsdk-linux-${DART_ARCH}-release.zip" \
+       -o /tmp/dart-sdk.zip \
+    && unzip -q /tmp/dart-sdk.zip -d /usr/local \
+    && rm /tmp/dart-sdk.zip \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV PATH="/usr/local/dart-sdk/bin:${PATH}"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,13 +1,16 @@
 {
   "name": "pyramid-client-builder",
-  "image": "mcr.microsoft.com/devcontainers/python:3.12",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
   "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:2": {
       "moby": false
     },
     "ghcr.io/devcontainers/features/github-cli:1": {},
     "ghcr.io/devcontainers/features/aws-cli:1": {},
-    "ghcr.io/jsburckhardt/devcontainer-features/uv:1": {}
+    "ghcr.io/jsburckhardt/devcontainer-features/uv:1": {},
+    "ghcr.io/devcontainers/features/go:1": {}
   },
   "customizations": {
     "vscode": {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,9 +46,28 @@ jobs:
       - name: Test
         run: uvx --with tox-uv tox -e ${{ matrix.tox-env }}
 
+  smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.21'
+
+      - uses: dart-lang/setup-dart@v1
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Smoke tests
+        run: uv run pytest tests/test_smoke.py -v
+
   publish:
     if: github.event_name == 'release'
-    needs: [lint, test]
+    needs: [lint, test, smoke]
     runs-on: ubuntu-latest
     environment: pypi
     permissions:
@@ -71,7 +90,7 @@ jobs:
 
   docs:
     if: github.event_name == 'release'
-    needs: [lint, test]
+    needs: [lint, test, smoke]
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,4 +62,5 @@ dev = [
     "tox",
     "tox-uv>=1.25",
     "pre-commit",
+    "httpx",
 ]

--- a/src/pyramid_client_builder/generator/flutter_core.py
+++ b/src/pyramid_client_builder/generator/flutter_core.py
@@ -26,6 +26,7 @@ from pyramid_client_builder.generator.flutter_naming import (
     to_dart_type,
     to_dart_version_class,
     to_dart_version_field,
+    to_dart_version_prefix,
 )
 from pyramid_client_builder.generator.renderer import render_tree
 from pyramid_client_builder.models import ClientSpec, EndpointInfo
@@ -143,6 +144,7 @@ class FlutterClientGenerator:
         env.filters["dart_param_name"] = snake_to_camel
         env.filters["dart_version_field"] = to_dart_version_field
         env.filters["dart_version_class"] = to_dart_version_class
+        env.filters["dart_version_prefix"] = to_dart_version_prefix
         env.filters["dart_json_key"] = _dart_json_key_filter
         env.filters["dart_from_json_value"] = _dart_from_json_value_filter
         env.filters["dart_to_json_value"] = _dart_to_json_value_filter

--- a/src/pyramid_client_builder/generator/flutter_naming.py
+++ b/src/pyramid_client_builder/generator/flutter_naming.py
@@ -26,8 +26,6 @@ DART_TYPE_MAP = {
 }
 
 NULLABLE_ALWAYS = {
-    "List<dynamic>",
-    "Map<String, dynamic>",
     "dynamic",
 }
 
@@ -124,6 +122,18 @@ def to_dart_type(field_type: str, required: bool = True) -> str:
     if not required and dart_type not in NULLABLE_ALWAYS:
         return f"{dart_type}?"
     return dart_type
+
+
+def to_dart_version_prefix(version: str) -> str:
+    """Convert a version string to a Dart import prefix.
+
+    Uses a distinct name to avoid shadowing the field name.
+
+    Examples:
+        "v1" -> "v1_api"
+        "v2" -> "v2_api"
+    """
+    return f"{version.lower()}_api"
 
 
 def to_dart_version_field(version: str) -> str:

--- a/src/pyramid_client_builder/generator/flutter_templates/lib/src/client.dart.j2
+++ b/src/pyramid_client_builder/generator/flutter_templates/lib/src/client.dart.j2
@@ -6,7 +6,7 @@ import 'package:http/http.dart' as http;
 import 'models.dart';
 {% endif %}
 {% for version in versions %}
-import '{{ version }}/client.dart' as {{ version }};
+import '{{ version }}/client.dart' as {{ version | dart_version_prefix }};
 {% endfor %}
 
 /// HTTP client for the {{ spec.name }} service.
@@ -15,7 +15,7 @@ class {{ class_name }} {
   final http.Client _httpClient;
   String? authToken;
 {% for version in versions %}
-  late final {{ version }}.{{ version | dart_version_class }}Client {{ version | dart_version_field }};
+  late final {{ version | dart_version_prefix }}.{{ version | dart_version_class }}Client {{ version | dart_version_field }};
 {% endfor %}
 
   {{ class_name }}(
@@ -24,7 +24,7 @@ class {{ class_name }} {
     this.authToken,
   }) : _httpClient = httpClient ?? http.Client() {
 {% for version in versions %}
-    {{ version | dart_version_field }} = {{ version }}.{{ version | dart_version_class }}Client(baseUrl, _httpClient, authToken);
+    {{ version | dart_version_field }} = {{ version | dart_version_prefix }}.{{ version | dart_version_class }}Client(baseUrl, _httpClient, authToken);
 {% endfor %}
   }
 

--- a/tests/test_flutter_generator.py
+++ b/tests/test_flutter_generator.py
@@ -140,7 +140,7 @@ class TestFlutterGeneratorWithSimpleSpec:
         gen = FlutterClientGenerator(simple_spec)
         gen.generate(tmp_path)
         source = (tmp_path / "lib" / "src" / "client.dart").read_text()
-        assert "late final v1.V1Client v1" in source
+        assert "late final v1_api.V1Client v1" in source
 
     def test_root_client_has_constructor(self, simple_spec, tmp_path):
         gen = FlutterClientGenerator(simple_spec)
@@ -166,7 +166,7 @@ class TestFlutterGeneratorWithSimpleSpec:
         gen = FlutterClientGenerator(simple_spec)
         gen.generate(tmp_path)
         source = (tmp_path / "lib" / "src" / "client.dart").read_text()
-        assert "import 'v1/client.dart' as v1;" in source
+        assert "import 'v1/client.dart' as v1_api;" in source
 
     def test_v1_client_has_class_declaration(self, simple_spec, tmp_path):
         gen = FlutterClientGenerator(simple_spec)
@@ -263,7 +263,7 @@ class TestFlutterGeneratorWithExampleApp:
         gen = FlutterClientGenerator(example_spec)
         gen.generate(tmp_path)
         source = (tmp_path / "lib" / "src" / "client.dart").read_text()
-        assert "v1.V1Client v1" in source
+        assert "v1_api.V1Client v1" in source
 
 
 # ======================================================================

--- a/tests/test_flutter_naming.py
+++ b/tests/test_flutter_naming.py
@@ -158,13 +158,13 @@ class TestDartType:
     def test_datetime_optional(self):
         assert to_dart_type("DateTime", required=False) == "DateTime?"
 
-    def test_list_always_list(self):
+    def test_list(self):
         assert to_dart_type("List", required=True) == "List<dynamic>"
-        assert to_dart_type("List", required=False) == "List<dynamic>"
+        assert to_dart_type("List", required=False) == "List<dynamic>?"
 
     def test_dict(self):
         assert to_dart_type("Dict", required=True) == "Map<String, dynamic>"
-        assert to_dart_type("Dict", required=False) == "Map<String, dynamic>"
+        assert to_dart_type("Dict", required=False) == "Map<String, dynamic>?"
 
     def test_uuid_is_string(self):
         assert to_dart_type("UUID", required=True) == "String"

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,0 +1,85 @@
+"""Smoke tests that verify generated code actually works."""
+
+import os
+import subprocess
+import sys
+
+from click.testing import CliRunner
+
+from pyramid_client_builder.cli import pclient_build
+
+
+class TestSmokeGenerated:
+
+    def _generate(self, tmp_path):
+        runner = CliRunner()
+        result = runner.invoke(
+            pclient_build,
+            [
+                "tests/example_app/example.ini",
+                "--name",
+                "example",
+                "--output",
+                str(tmp_path),
+            ],
+        )
+        assert result.exit_code == 0, result.output
+
+    def test_python_requests_import_and_instantiate(self, tmp_path):
+        self._generate(tmp_path)
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                "from example_client import ExampleClient; "
+                "c = ExampleClient('http://localhost'); "
+                "assert hasattr(c, 'v1')",
+            ],
+            env={**os.environ, "PYTHONPATH": str(tmp_path / "python_requests")},
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, result.stderr
+
+    def test_python_httpx_import_and_instantiate(self, tmp_path):
+        self._generate(tmp_path)
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                "from example_client import ExampleClient; "
+                "c = ExampleClient('http://localhost'); "
+                "assert hasattr(c, 'v1')",
+            ],
+            env={**os.environ, "PYTHONPATH": str(tmp_path / "python_httpx")},
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, result.stderr
+
+    def test_go_compiles(self, tmp_path):
+        self._generate(tmp_path)
+        result = subprocess.run(
+            ["go", "build", "./..."],
+            cwd=str(tmp_path / "go"),
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, result.stderr
+
+    def test_flutter_dart_analyzes(self, tmp_path):
+        self._generate(tmp_path)
+        dart_dir = tmp_path / "flutter"
+        subprocess.run(
+            ["dart", "pub", "get"],
+            cwd=str(dart_dir),
+            check=True,
+            capture_output=True,
+        )
+        result = subprocess.run(
+            ["dart", "analyze", "--fatal-infos"],
+            cwd=str(dart_dir),
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, result.stderr

--- a/uv.lock
+++ b/uv.lock
@@ -7,6 +7,20 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "anyio"
+version = "4.12.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/96/f0/5eb65b2bb0d09ac6776f2eb54adee6abe8228ea05b20a5ad0e4945de8aac/anyio-4.12.1.tar.gz", hash = "sha256:41cfcc3a4c85d3f05c932da7c26d0201ac36f72abd4435ba90d0464a3ffed703", size = 228685, upload-time = "2026-01-06T11:45:21.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/0e/27be9fdef66e72d64c0cdc3cc2823101b80585f8119b5c112c2e8f5f7dab/anyio-4.12.1-py3-none-any.whl", hash = "sha256:d405828884fc140aa80a3c667b8beed277f1dfedec42ba031bd6ac3db606ab6c", size = 113592, upload-time = "2026-01-06T11:45:19.497Z" },
+]
+
+[[package]]
 name = "babel"
 version = "2.18.0"
 source = { registry = "https://pypi.org/simple" }
@@ -309,6 +323,43 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d9/29/d40217cbe2f6b1359e00c6c307bb3fc876ba74068cbab3dde77f03ca0dc4/ghp-import-2.1.0.tar.gz", hash = "sha256:9c535c4c61193c2df8871222567d7fd7e5014d835f97dc7b7439069e2413d343", size = 10943, upload-time = "2022-05-02T15:47:16.11Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f7/ec/67fbef5d497f86283db54c22eec6f6140243aae73265799baaaa19cd17fb/ghp_import-2.1.0-py3-none-any.whl", hash = "sha256:8337dd7b50877f163d4c0289bc1f1c7f127550241988d568c1db512c4324a619", size = 11034, upload-time = "2022-05-02T15:47:14.552Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
 ]
 
 [[package]]
@@ -757,6 +808,7 @@ dependencies = [
 dev = [
     { name = "black" },
     { name = "cornice" },
+    { name = "httpx" },
     { name = "marshmallow" },
     { name = "mkdocs-material" },
     { name = "pre-commit" },
@@ -780,6 +832,7 @@ requires-dist = [
 dev = [
     { name = "black" },
     { name = "cornice" },
+    { name = "httpx" },
     { name = "marshmallow" },
     { name = "mkdocs-material" },
     { name = "pre-commit" },


### PR DESCRIPTION
## Summary

- Add smoke tests that verify generated clients actually work: Python import+instantiate, Go compile, Dart analyze
- Fix two Dart template bugs caught by the new smoke tests (import prefix shadowing, non-nullable optional params)
- Add Go and Dart SDKs to devcontainer (Dockerfile + feature) and a dedicated `smoke` CI job

Closes #17

## Test plan

- [x] `make check` passes (416 tests, 0 failures)
- [x] Python requests smoke test: imports and instantiates `ExampleClient`
- [x] Python httpx smoke test: imports and instantiates `ExampleClient`
- [x] Go smoke test: `go build ./...` compiles generated code
- [x] Dart smoke test: `dart pub get` + `dart analyze --fatal-infos` passes
- [ ] CI `smoke` job passes with Go + Dart setup actions