### PR TITLE
Fix path params with regex patterns breaking schema naming

### DIFF
--- a/src/pyramid_client_builder/generator/naming.py
+++ b/src/pyramid_client_builder/generator/naming.py
@@ -26,7 +26,14 @@ def _ensure_wordnet():
 _ROUTE_NAME_SEPS = re.compile(r"[-_]+")
 _DUPLICATE_UNDERSCORES = re.compile(r"_+")
 _PATH_PARAM = re.compile(r"\{[^}]+\}")
+_PATH_REGEX = re.compile(r"\{(\w+)(?::.*?)\}")
 _VERSION_RE = re.compile(r"v(\d+)")
+
+
+def _strip_path_regex(path: str) -> str:
+    """Remove regex constraints from path params: {id:\\d+} -> {id}."""
+    return _PATH_REGEX.sub(r"{\1}", path)
+
 
 _ROLE_SUFFIXES = (
     "RequestSchema",
@@ -133,6 +140,7 @@ def extract_version(path: str) -> str | None:
         "/health"               -> None
         "/"                     -> None
     """
+    path = _strip_path_regex(path)
     for seg in path.strip("/").split("/"):
         if _VERSION_RE.fullmatch(seg):
             return seg
@@ -199,6 +207,7 @@ def _path_segments(path: str) -> list[str]:
     "/" -> []
     "/health" -> ["health"]
     """
+    path = _strip_path_regex(path)
     raw = path.strip("/").split("/")
     segments = []
     for seg in raw:
@@ -281,6 +290,7 @@ _HTTP_PREFIX = {
 
 def _ends_with_param(path: str) -> bool:
     """Check if the path ends with a path parameter like /{id}."""
+    path = _strip_path_regex(path)
     last_segment = path.rstrip("/").rsplit("/", 1)[-1]
     return bool(_PATH_PARAM.fullmatch(last_segment))
 

--- a/tests/example_app/schemas.py
+++ b/tests/example_app/schemas.py
@@ -95,3 +95,19 @@ class SimulateResponseSchema(ma.Schema):
 class RequestErrorSchema(ma.Schema):
     error = ma.fields.String()
     details = ma.fields.Dict()
+
+
+# --- Company relationship schemas (regex path param pattern) ---
+
+
+class CompanyRelationshipsResponseSchema(ma.Schema):
+    total = ma.fields.Integer()
+    uuid_or_tax_id = ma.fields.String()
+
+
+class CompanyRelationshipQuerySchema(ma.Schema):
+    legal_entity_type = ma.fields.String(required=False)
+
+
+class CompanyRelationshipPathSchema(ma.Schema):
+    uuid_or_tax_id = ma.fields.String(required=True)

--- a/tests/example_app/views.py
+++ b/tests/example_app/views.py
@@ -11,6 +11,9 @@ from tests.example_app.schemas import (
     ChargeRequestSchema,
     ChargeResponseSchema,
     ChargesQuerySchema,
+    CompanyRelationshipPathSchema,
+    CompanyRelationshipQuerySchema,
+    CompanyRelationshipsResponseSchema,
     InvoiceQuerySchema,
     RefundRequestSchema,
     RequestErrorSchema,
@@ -147,6 +150,29 @@ simulate_service = Service(
 def simulate_financing(request):
     """Simulate a financing plan."""
     return {"monthly_payment": 100.0, "total_interest": 200.0, "total_amount": 1200.0}
+
+
+# --- Cornice service with regex path param (company relationships) ---
+
+company_relationship_service = Service(
+    name="company_relationship",
+    path=r"/api/v1/companies/{uuid_or_tax_id:[^/]+}/relationships",
+    description="Company relationships API",
+    cors_origins=("*",),
+)
+
+
+@company_relationship_service.get(
+    pcm_show="v1",
+    pcm_request=dict(
+        path=CompanyRelationshipPathSchema,
+        querystring=CompanyRelationshipQuerySchema,
+    ),
+    pcm_responses={200: CompanyRelationshipsResponseSchema},
+)
+def list_company_relationships(request):
+    """List relationships for a company."""
+    return {"company_relationships": []}
 
 
 def includeme(config):

--- a/tests/test_naming.py
+++ b/tests/test_naming.py
@@ -94,6 +94,21 @@ class TestToSchemaName:
                 "querystring",
                 "SplitAccountsQuerySchema",
             ),
+            (
+                r"/api/v1/companies/{uuid_or_tax_id:[^/]+}/relationships",
+                "response",
+                "CompaniesRelationshipsResponseSchema",
+            ),
+            (
+                r"/api/v1/companies/{uuid_or_tax_id:[^/]+}/relationships",
+                "querystring",
+                "CompaniesRelationshipsQuerySchema",
+            ),
+            (
+                r"/api/v1/charges/{id:\d+}",
+                "response",
+                "ChargesResponseSchema",
+            ),
         ],
     )
     def test_schema_name_from_path(self, path, role, expected):
@@ -144,6 +159,7 @@ class TestExtractVersion:
             ("/api/v2/invoices/{id}", "v2"),
             ("/v3/items", "v3"),
             ("/api/v10/resources", "v10"),
+            (r"/api/v1/companies/{uuid_or_tax_id:[^/]+}/relationships", "v1"),
         ],
     )
     def test_extracts_version(self, path, expected):
@@ -222,6 +238,12 @@ class TestToMethodNameDetail:
             ("charge_detail", "DELETE", "/api/v1/charges/{charge_id}", "delete_charge"),
             ("charge_detail", "PUT", "/api/v1/charges/{charge_id}", "update_charge"),
             ("charge_detail", "PATCH", "/api/v1/charges/{charge_id}", "patch_charge"),
+            (
+                "company_relationship",
+                "GET",
+                r"/api/v1/companies/{uuid_or_tax_id:[^/]+}/relationships",
+                "get_companies_relationship",
+            ),
         ],
     )
     def test_detail_endpoints(self, route_name, method, path, expected):


### PR DESCRIPTION
## Summary

- Strip regex constraints from path parameters before `/`-splitting in `naming.py`, fixing broken schema names like `Companies{uuidOrTaxId:[^]+}ResponseSchema`
- Applied `_strip_path_regex()` normalization in `_path_segments()`, `_ends_with_param()`, and `extract_version()`
- Added company relationship service with regex path `{uuid_or_tax_id:[^/]+}` to the example app so smoke tests cover this pattern end-to-end

Closes #19

## Test plan

- [x] Unit tests for schema naming with regex path params (`[^/]+`, `\d+`)
- [x] Unit tests for method naming with regex path params
- [x] Unit test for version extraction with regex path params
- [x] Smoke tests pass (Python requests, Python httpx, Go, Flutter)
- [x] `make check` passes (ruff + black + pytest)