### PR TITLE
Static views with wildcard paths generate invalid Python method names

### DIFF
--- a/src/pyramid_client_builder/generator/core.py
+++ b/src/pyramid_client_builder/generator/core.py
@@ -66,7 +66,9 @@ class ClientGenerator:
         output_path = Path(output_dir)
         output_path.mkdir(parents=True, exist_ok=True)
 
-        versioned, unversioned = group_by_version(self.spec.endpoints)
+        endpoints = [ep for ep in self.spec.endpoints if "*" not in ep.path]
+
+        versioned, unversioned = group_by_version(endpoints)
 
         versions_ctx: dict[str, dict] = {}
         for version in sorted(versioned.keys()):

--- a/src/pyramid_client_builder/generator/flutter_core.py
+++ b/src/pyramid_client_builder/generator/flutter_core.py
@@ -72,7 +72,9 @@ class FlutterClientGenerator:
         output_path = Path(output_dir)
         output_path.mkdir(parents=True, exist_ok=True)
 
-        versioned, unversioned = group_by_version(self.spec.endpoints)
+        endpoints = [ep for ep in self.spec.endpoints if "*" not in ep.path]
+
+        versioned, unversioned = group_by_version(endpoints)
 
         versions_ctx: dict[str, dict] = {}
         for ver in sorted(versioned.keys()):

--- a/src/pyramid_client_builder/generator/go_core.py
+++ b/src/pyramid_client_builder/generator/go_core.py
@@ -71,7 +71,9 @@ class GoClientGenerator:
         output_path = Path(output_dir)
         output_path.mkdir(parents=True, exist_ok=True)
 
-        versioned, unversioned = group_by_version(self.spec.endpoints)
+        endpoints = [ep for ep in self.spec.endpoints if "*" not in ep.path]
+
+        versioned, unversioned = group_by_version(endpoints)
 
         versions_ctx: dict[str, dict] = {}
         for ver in sorted(versioned.keys()):

--- a/src/pyramid_client_builder/generator/naming.py
+++ b/src/pyramid_client_builder/generator/naming.py
@@ -206,6 +206,7 @@ def _path_segments(path: str) -> list[str]:
     "/api/v1/charges/{charge_id}/cancel" -> ["charges", "cancel"]
     "/" -> []
     "/health" -> ["health"]
+    "static/*subpath" -> ["static"]
     """
     path = _strip_path_regex(path)
     raw = path.strip("/").split("/")
@@ -214,6 +215,8 @@ def _path_segments(path: str) -> list[str]:
         if not seg:
             continue
         if _PATH_PARAM.fullmatch(seg):
+            continue
+        if "*" in seg:
             continue
         if seg.lower() in _API_PREFIXES:
             continue

--- a/src/pyramid_client_builder/introspection.py
+++ b/src/pyramid_client_builder/introspection.py
@@ -44,6 +44,8 @@ class PyramidIntrospector:
 
         endpoints = _routes_to_endpoints(routes)
 
+        endpoints = _drop_wildcard_routes(endpoints)
+
         endpoints = _drop_non_client_methods(endpoints)
 
         endpoints = _filter_endpoints(endpoints, include_patterns, exclude_patterns)
@@ -74,6 +76,15 @@ def _routes_to_endpoints(routes: list) -> list[EndpointInfo]:
                 )
             )
     return endpoints
+
+
+def _drop_wildcard_routes(endpoints: list[EndpointInfo]) -> list[EndpointInfo]:
+    """Remove routes with wildcard patterns (e.g. static/*subpath).
+
+    Pyramid uses ``*name`` for traversal and static views — these are
+    never API endpoints and would produce invalid Python identifiers.
+    """
+    return [ep for ep in endpoints if "*" not in ep.path]
 
 
 def _drop_non_client_methods(endpoints: list[EndpointInfo]) -> list[EndpointInfo]:

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -908,3 +908,55 @@ class TestHttpClientOption:
         v1_source = (package_dir / "v1" / "client.py").read_text()
         assert "self.session.get(" in v1_source
         assert "self.session.post(" in v1_source
+
+
+# ======================================================================
+# Static / wildcard views (should be excluded from generated client)
+# ======================================================================
+
+
+class TestStaticViewsExcluded:
+    """Verify that Pyramid static views with wildcard paths don't break generation."""
+
+    @pytest.fixture()
+    def spec_with_static_view(self):
+        return ClientSpec(
+            name="myapp",
+            endpoints=[
+                EndpointInfo(name="home", path="/", method="GET", description="Home"),
+                EndpointInfo(
+                    name="items",
+                    path="/api/v1/items",
+                    method="GET",
+                    description="List items",
+                ),
+                EndpointInfo(
+                    name="__static/",
+                    path="static/*subpath",
+                    method="GET",
+                    description="An instance of this class is a callable ...",
+                ),
+            ],
+        )
+
+    def test_static_view_method_not_in_client(self, spec_with_static_view, tmp_path):
+        gen = ClientGenerator(spec_with_static_view)
+        package_dir = gen.generate(tmp_path)
+        all_source = ""
+        for py_file in package_dir.rglob("*.py"):
+            all_source += py_file.read_text()
+        assert "subpath" not in all_source
+        assert "static" not in all_source.replace("__static", "")
+
+    def test_normal_endpoints_still_generated(self, spec_with_static_view, tmp_path):
+        gen = ClientGenerator(spec_with_static_view)
+        package_dir = gen.generate(tmp_path)
+        root_source = (package_dir / "client.py").read_text()
+        assert "def get_home(self):" in root_source
+
+    def test_generated_files_are_valid_python(self, spec_with_static_view, tmp_path):
+        gen = ClientGenerator(spec_with_static_view)
+        package_dir = gen.generate(tmp_path)
+        for py_file in package_dir.rglob("*.py"):
+            source = py_file.read_text()
+            ast.parse(source, filename=str(py_file))

--- a/tests/test_naming.py
+++ b/tests/test_naming.py
@@ -3,6 +3,7 @@
 import pytest
 
 from pyramid_client_builder.generator.naming import (
+    _path_segments,
     extract_version,
     needs_schema_rename,
     to_class_name,
@@ -293,3 +294,23 @@ class TestToMethodNameSingularization:
     def test_singularization_in_detail(self, route_name, method, path, expected_suffix):
         result = to_method_name(route_name, method, path)
         assert result == expected_suffix
+
+
+class TestWildcardPaths:
+    """Wildcard segments (e.g. *subpath) must be skipped in path parsing."""
+
+    @pytest.mark.parametrize(
+        "path, expected",
+        [
+            ("static/*subpath", ["static"]),
+            ("assets/*remainder", ["assets"]),
+            ("/*traverse", []),
+        ],
+    )
+    def test_path_segments_skips_wildcard(self, path, expected):
+        assert _path_segments(path) == expected
+
+    def test_method_name_with_wildcard_produces_valid_identifier(self):
+        result = to_method_name("__static/", "GET", "static/*subpath")
+        assert result == "list_static"
+        assert result.isidentifier()


### PR DESCRIPTION
## Summary

- Filter out Pyramid wildcard routes (`*subpath`, `*traverse`, etc.) during introspection and in all generators (Python, Go, Flutter) so static views never produce invalid code
- Sanitize `_path_segments()` in the naming module to skip `*`-containing segments as a safety net
- Add integration and unit tests covering wildcard path handling

Closes #23

## Test plan

- [ ] `make check` passes (lint + 428 tests green)
- [ ] New `TestStaticViewsExcluded` tests verify static view endpoints are excluded from generated client and output is valid Python
- [ ] New `TestWildcardPaths` tests verify `_path_segments` skips wildcard segments and `to_method_name` produces valid identifiers