### PR TITLE
Add --skip and --only options to control which client variants are generated

### DIFF
--- a/knowledge/decisions.md
+++ b/knowledge/decisions.md
@@ -328,3 +328,15 @@ Use this format when adding a new decision:
 4. `_resolve_base_marshmallow_type` returns `"String"` instead of `"Field"` when the MRO walk reaches the base `Field` class, so generated stubs provide at least basic string serialization.
 
 **Consequences**: Generated Python clients import without errors. `Nested` fields lose their nested-schema validation (degraded to `Dict`), and `List` fields assume string inner type. Both are safe defaults given the metadata available. Custom fields extending bare `Field` now serialize as strings, which matches the common case (CNPJ, CPF, phone validators). When `pyramid-introspector` gains inner/nested metadata, the generator can emit precise types.
+
+---
+
+### 2026-03-28 — Variant selection via --skip and --only
+
+**Status**: Accepted (extends "Go client generation and multi-variant output")
+
+**Context**: The CLI always generated all four client variants (python_requests, python_httpx, go, flutter) with no way to opt out. Some projects have no use for certain variants — for example, a backend-only service has no need for a Flutter client, or a mobile team only needs the Dart output. Generating unnecessary variants wastes time and clutters the output directory.
+
+**Decision**: Add two mutually exclusive, repeatable CLI options: `--skip <variant>` to exclude specific variants and `--only <variant>` to generate only the specified variants. Valid variant names match the output directory names: `python_requests`, `python_httpx`, `go`, `flutter`. When neither option is given, all variants are generated (backward compatible). Using both `--skip` and `--only` in the same invocation is a `UsageError`. Skipping all variants is also an error. Invalid variant names are rejected by Click's `Choice` type with a helpful error message. The `ALL_VARIANTS` tuple is defined as a module-level constant for reuse.
+
+**Consequences**: Users can tailor output to their needs without post-generation cleanup. The default behavior is unchanged — existing scripts and workflows are unaffected. The two options cover both mental models: "give me everything except X" (`--skip`) and "give me only X" (`--only`). The mutual exclusion constraint keeps semantics unambiguous.

--- a/src/pyramid_client_builder/cli.py
+++ b/src/pyramid_client_builder/cli.py
@@ -18,6 +18,8 @@ from pyramid_client_builder.introspection import PyramidIntrospector
 
 logger = logging.getLogger(__name__)
 
+ALL_VARIANTS = ("python_requests", "python_httpx", "go", "flutter")
+
 
 @click.command()
 @click.version_option(package_name="pyramid-client-builder")
@@ -61,6 +63,22 @@ logger = logging.getLogger(__name__)
     default="",
     help="Dart package name (e.g. 'payments_client'). " "Defaults to '<name>_client'.",
 )
+@click.option(
+    "--only",
+    multiple=True,
+    type=click.Choice(ALL_VARIANTS),
+    help="Generate only the specified variant(s). "
+    "Can be repeated (e.g. --only go --only flutter). "
+    "Mutually exclusive with --skip.",
+)
+@click.option(
+    "--skip",
+    multiple=True,
+    type=click.Choice(ALL_VARIANTS),
+    help="Skip the specified variant(s). "
+    "Can be repeated (e.g. --skip flutter --skip go). "
+    "Mutually exclusive with --only.",
+)
 @click.option("--debug", is_flag=True, help="Enable debug logging.")
 def pclient_build(
     ini_file,
@@ -71,6 +89,8 @@ def pclient_build(
     client_version,
     go_module,
     flutter_package,
+    only,
+    skip,
     debug,
 ):
     """Generate HTTP clients from a Pyramid application's routes.
@@ -79,13 +99,31 @@ def pclient_build(
     services, and writes client packages for all supported variants
     (python_requests, python_httpx, go, flutter) into subdirectories of --output.
 
+    Use --only or --skip to control which variants are generated.
+
     Examples:
 
         pclient-build development.ini --name payments --output ./generated/
 
         pclient-build production.ini --name payments --output ./clients/ \\
             --include "/api/v1/*" --exclude "/api/v1/webhooks/*"
+
+        pclient-build development.ini --name payments --output ./generated/ \\
+            --skip flutter --skip go
+
+        pclient-build development.ini --name payments --output ./generated/ \\
+            --only python_requests
     """
+    if only and skip:
+        raise click.UsageError("--only and --skip are mutually exclusive.")
+
+    selected = set(only) if only else set(ALL_VARIANTS) - set(skip)
+
+    if not selected:
+        raise click.UsageError(
+            "No variants to generate. " "All variants were skipped via --skip."
+        )
+
     log_level = logging.DEBUG if debug else logging.INFO
     logging.basicConfig(
         level=log_level,
@@ -119,7 +157,7 @@ def pclient_build(
 
         output_path = Path(output)
 
-        variants = [
+        all_variants = [
             (
                 "python_requests",
                 ClientGenerator(spec, version=client_version, http_client="requests"),
@@ -142,15 +180,18 @@ def pclient_build(
             ),
         ]
 
+        variants = [(vname, gen) for vname, gen in all_variants if vname in selected]
+
         for variant_name, generator in variants:
             variant_dir = output_path / variant_name
             generator.generate(variant_dir)
             click.echo(f"  Generated {variant_name}/ ", err=True)
 
+        variant_names = ", ".join(vname for vname, _ in variants)
         click.echo("", err=True)
         click.echo(f"Generated clients at {output_path}", err=True)
         click.echo(f"  Name:      {name}", err=True)
-        click.echo("  Variants:  python_requests, python_httpx, go, flutter", err=True)
+        click.echo(f"  Variants:  {variant_names}", err=True)
         click.echo(f"  Endpoints: {len(spec.endpoints)}", err=True)
         click.echo(f"  Settings:  {spec.settings_prefix}.base_url", err=True)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -244,3 +244,167 @@ class TestPclientBuild:
         assert "python_requests" in result.output
         assert "python_httpx" in result.output
         assert "go" in result.output
+
+    def test_skip_flutter_variant(self, tmp_path):
+        runner = CliRunner()
+        result = runner.invoke(
+            pclient_build,
+            [
+                "tests/example_app/example.ini",
+                "--name",
+                "example",
+                "--output",
+                str(tmp_path),
+                "--skip",
+                "flutter",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert (tmp_path / "python_requests").is_dir()
+        assert (tmp_path / "python_httpx").is_dir()
+        assert (tmp_path / "go").is_dir()
+        assert not (tmp_path / "flutter").exists()
+
+    def test_skip_multiple_variants(self, tmp_path):
+        runner = CliRunner()
+        result = runner.invoke(
+            pclient_build,
+            [
+                "tests/example_app/example.ini",
+                "--name",
+                "example",
+                "--output",
+                str(tmp_path),
+                "--skip",
+                "flutter",
+                "--skip",
+                "go",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert (tmp_path / "python_requests").is_dir()
+        assert (tmp_path / "python_httpx").is_dir()
+        assert not (tmp_path / "go").exists()
+        assert not (tmp_path / "flutter").exists()
+
+    def test_only_go_variant(self, tmp_path):
+        runner = CliRunner()
+        result = runner.invoke(
+            pclient_build,
+            [
+                "tests/example_app/example.ini",
+                "--name",
+                "example",
+                "--output",
+                str(tmp_path),
+                "--only",
+                "go",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert (tmp_path / "go").is_dir()
+        assert not (tmp_path / "python_requests").exists()
+        assert not (tmp_path / "python_httpx").exists()
+        assert not (tmp_path / "flutter").exists()
+
+    def test_only_multiple_variants(self, tmp_path):
+        runner = CliRunner()
+        result = runner.invoke(
+            pclient_build,
+            [
+                "tests/example_app/example.ini",
+                "--name",
+                "example",
+                "--output",
+                str(tmp_path),
+                "--only",
+                "python_requests",
+                "--only",
+                "go",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert (tmp_path / "python_requests").is_dir()
+        assert (tmp_path / "go").is_dir()
+        assert not (tmp_path / "python_httpx").exists()
+        assert not (tmp_path / "flutter").exists()
+
+    def test_skip_and_only_mutual_exclusion(self, tmp_path):
+        runner = CliRunner()
+        result = runner.invoke(
+            pclient_build,
+            [
+                "tests/example_app/example.ini",
+                "--name",
+                "example",
+                "--output",
+                str(tmp_path),
+                "--skip",
+                "flutter",
+                "--only",
+                "go",
+            ],
+        )
+        assert result.exit_code != 0
+        assert "mutually exclusive" in result.output
+
+    def test_skip_all_variants_fails(self, tmp_path):
+        runner = CliRunner()
+        result = runner.invoke(
+            pclient_build,
+            [
+                "tests/example_app/example.ini",
+                "--name",
+                "example",
+                "--output",
+                str(tmp_path),
+                "--skip",
+                "python_requests",
+                "--skip",
+                "python_httpx",
+                "--skip",
+                "go",
+                "--skip",
+                "flutter",
+            ],
+        )
+        assert result.exit_code != 0
+        assert "No variants to generate" in result.output
+
+    def test_invalid_variant_name(self, tmp_path):
+        runner = CliRunner()
+        result = runner.invoke(
+            pclient_build,
+            [
+                "tests/example_app/example.ini",
+                "--name",
+                "example",
+                "--output",
+                str(tmp_path),
+                "--skip",
+                "java",
+            ],
+        )
+        assert result.exit_code != 0
+
+    def test_summary_reflects_selected_variants(self, tmp_path):
+        runner = CliRunner()
+        result = runner.invoke(
+            pclient_build,
+            [
+                "tests/example_app/example.ini",
+                "--name",
+                "example",
+                "--output",
+                str(tmp_path),
+                "--only",
+                "go",
+                "--go-module",
+                "github.com/org/example-client",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert "go" in result.output
+        assert "python_requests" not in result.output
+        assert "python_httpx" not in result.output
+        assert "flutter" not in result.output


### PR DESCRIPTION
## Summary

- Add `--skip` and `--only` mutually exclusive CLI options to selectively generate client variants (python_requests, python_httpx, go, flutter)
- Default behavior unchanged: all variants generated when neither flag is used
- Includes validation for mutual exclusion, empty selection, and invalid names (via Click Choice)

Closes #27

## Test plan

- [ ] `--skip flutter` generates 3 variants, no flutter/ directory
- [ ] `--skip flutter --skip go` generates only the 2 Python variants
- [ ] `--only go` generates only go/ directory
- [ ] `--only python_requests --only go` generates exactly those two
- [ ] `--skip flutter --only go` fails with "mutually exclusive" error
- [ ] Skipping all 4 variants fails with "No variants to generate" error
- [ ] `--skip java` (invalid name) fails with Click Choice error
- [ ] Summary output lists only the variants that were generated
- [ ] No flags: all 4 variants generated (backward compatible)