### PR TITLE
Fix Python client marshmallow field generation bugs (blockers + validation)

### DIFF
--- a/src/pyramid_client_builder/generator/core.py
+++ b/src/pyramid_client_builder/generator/core.py
@@ -212,8 +212,14 @@ def _format_doc_path_filter(endpoint: EndpointInfo) -> str:
 
 
 def _field_kwargs_filter(field_info: SchemaFieldInfo) -> str:
-    """Render Marshmallow field constructor keyword arguments."""
+    """Render Marshmallow field constructor arguments.
+
+    For ``List`` fields, prepends ``ma.fields.String()`` as the required
+    inner type since ``SchemaFieldInfo`` does not carry inner-field metadata.
+    """
     parts: list[str] = []
+    if field_info.field_type == "List":
+        parts.append("ma.fields.String()")
     if field_info.required:
         parts.append("required=True")
     if field_info.metadata:

--- a/src/pyramid_client_builder/generator/python_templates/{{package_name}}/@each(versions)/schemas.py.j2
+++ b/src/pyramid_client_builder/generator/python_templates/{{package_name}}/@each(versions)/schemas.py.j2
@@ -18,7 +18,9 @@ class {{ schema.name }}(ma.Schema):
     pass
 {% else %}
 {% for field in schema.fields %}
-{% if field.field_type in custom_field_names %}
+{% if field.field_type == 'Nested' %}
+    {{ field.name }} = ma.fields.Dict({{ field | field_kwargs }})
+{% elif field.field_type in custom_field_names %}
     {{ field.name }} = {{ field.field_type }}({{ field | field_kwargs }})
 {% else %}
     {{ field.name }} = ma.fields.{{ field.field_type }}({{ field | field_kwargs }})

--- a/src/pyramid_client_builder/generator/python_templates/{{package_name}}/fields.py.j2
+++ b/src/pyramid_client_builder/generator/python_templates/{{package_name}}/fields.py.j2
@@ -6,6 +6,14 @@ import marshmallow as ma
 
 
 class {{ cf.class_name }}(ma.fields.{{ cf.base_type }}):
+{% if cf.base_type == 'List' %}
+    def __init__(self, inner=None, **kwargs):
+        super().__init__(inner or ma.fields.String(), **kwargs)
+{% elif cf.base_type == 'Nested' %}
+    def __init__(self, nested=None, **kwargs):
+        super().__init__(nested or ma.Schema, **kwargs)
+{% else %}
     pass
+{% endif %}
 {% endfor %}
 {% endif %}

--- a/src/pyramid_client_builder/generator/python_templates/{{package_name}}/schemas.py.j2
+++ b/src/pyramid_client_builder/generator/python_templates/{{package_name}}/schemas.py.j2
@@ -18,7 +18,9 @@ class {{ schema.name }}(ma.Schema):
     pass
 {% else %}
 {% for field in schema.fields %}
-{% if field.field_type in custom_field_names %}
+{% if field.field_type == 'Nested' %}
+    {{ field.name }} = ma.fields.Dict({{ field | field_kwargs }})
+{% elif field.field_type in custom_field_names %}
     {{ field.name }} = {{ field.field_type }}({{ field | field_kwargs }})
 {% else %}
     {{ field.name }} = ma.fields.{{ field.field_type }}({{ field | field_kwargs }})

--- a/src/pyramid_client_builder/introspection.py
+++ b/src/pyramid_client_builder/introspection.py
@@ -235,11 +235,16 @@ def _collect_schema_classes(routes: list) -> list[type]:
 
 
 def _resolve_base_marshmallow_type(field_cls: type) -> str | None:
-    """Walk the MRO to find the first standard Marshmallow field ancestor."""
+    """Walk the MRO to find the first standard Marshmallow field ancestor.
+
+    When the walk reaches the base ``Field`` class without finding a more
+    specific ancestor, ``"String"`` is returned instead of ``"Field"`` so
+    the generated stub provides at least basic string serialization.
+    """
     for ancestor in field_cls.__mro__:
         if ancestor.__name__ in _STANDARD_FIELD_NAMES:
             if ancestor is marshmallow.fields.Field:
-                return "Field"
+                return "String"
             return ancestor.__name__
     return None
 

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -1274,3 +1274,213 @@ class TestCustomFieldGeneration:
         for py_file in package_dir.rglob("*.py"):
             source = py_file.read_text()
             ast.parse(source, filename=str(py_file))
+
+
+# ======================================================================
+# Custom field base-type edge cases (List, Nested, bare Field)
+# ======================================================================
+
+
+class TestCustomFieldListBaseType:
+    """Custom List fields get an __init__ with a default inner type."""
+
+    @pytest.fixture()
+    def spec_with_list_custom_field(self):
+        from pyramid_client_builder.models import CustomFieldInfo
+
+        schema = SchemaInfo(
+            name="FilterRequestSchema",
+            fields=[
+                SchemaFieldInfo(name="tags", field_type="TagListField", required=True),
+            ],
+        )
+        return ClientSpec(
+            name="search",
+            endpoints=[
+                EndpointInfo(
+                    name="search",
+                    path="/api/v1/search",
+                    method="GET",
+                    querystring_schema=schema,
+                    parameters=[
+                        ParameterInfo(
+                            name="tags", location="querystring", type_hint="list"
+                        ),
+                    ],
+                ),
+            ],
+            custom_fields=[
+                CustomFieldInfo(class_name="TagListField", base_type="List"),
+            ],
+        )
+
+    def test_list_custom_field_has_init(self, spec_with_list_custom_field, tmp_path):
+        gen = ClientGenerator(spec_with_list_custom_field)
+        package_dir = gen.generate(tmp_path)
+        source = (package_dir / "fields.py").read_text()
+        assert "def __init__" in source
+        assert "ma.fields.String()" in source
+
+    def test_list_custom_field_is_valid_python(
+        self, spec_with_list_custom_field, tmp_path
+    ):
+        gen = ClientGenerator(spec_with_list_custom_field)
+        package_dir = gen.generate(tmp_path)
+        for py_file in package_dir.rglob("*.py"):
+            source = py_file.read_text()
+            ast.parse(source, filename=str(py_file))
+
+
+class TestCustomFieldNestedBaseType:
+    """Custom Nested fields get an __init__ with a default schema."""
+
+    @pytest.fixture()
+    def spec_with_nested_custom_field(self):
+        from pyramid_client_builder.models import CustomFieldInfo
+
+        schema = SchemaInfo(
+            name="OrderRequestSchema",
+            fields=[
+                SchemaFieldInfo(
+                    name="details", field_type="DetailField", required=True
+                ),
+            ],
+        )
+        return ClientSpec(
+            name="orders",
+            endpoints=[
+                EndpointInfo(
+                    name="orders",
+                    path="/api/v1/orders",
+                    method="POST",
+                    request_schema=schema,
+                    parameters=[
+                        ParameterInfo(
+                            name="details", location="body", type_hint="dict"
+                        ),
+                    ],
+                ),
+            ],
+            custom_fields=[
+                CustomFieldInfo(class_name="DetailField", base_type="Nested"),
+            ],
+        )
+
+    def test_nested_custom_field_has_init(
+        self, spec_with_nested_custom_field, tmp_path
+    ):
+        gen = ClientGenerator(spec_with_nested_custom_field)
+        package_dir = gen.generate(tmp_path)
+        source = (package_dir / "fields.py").read_text()
+        assert "def __init__" in source
+        assert "ma.Schema" in source
+
+    def test_nested_custom_field_is_valid_python(
+        self, spec_with_nested_custom_field, tmp_path
+    ):
+        gen = ClientGenerator(spec_with_nested_custom_field)
+        package_dir = gen.generate(tmp_path)
+        for py_file in package_dir.rglob("*.py"):
+            source = py_file.read_text()
+            ast.parse(source, filename=str(py_file))
+
+
+# ======================================================================
+# Schema fields: Nested -> Dict fallback, List with inner type
+# ======================================================================
+
+
+class TestNestedFieldFallback:
+    """Nested schema fields without a schema reference fall back to Dict."""
+
+    @pytest.fixture()
+    def spec_with_nested_schema_field(self):
+        schema = SchemaInfo(
+            name="EntityResponseSchema",
+            fields=[
+                SchemaFieldInfo(name="name", field_type="String", required=True),
+                SchemaFieldInfo(
+                    name="phones",
+                    field_type="Nested",
+                    metadata={"description": "Phone list"},
+                ),
+                SchemaFieldInfo(
+                    name="documents",
+                    field_type="Nested",
+                    metadata={"description": "Document list"},
+                ),
+            ],
+        )
+        return ClientSpec(
+            name="legal_entity",
+            endpoints=[
+                EndpointInfo(
+                    name="entities",
+                    path="/api/v1/entities",
+                    method="GET",
+                    response_schema=schema,
+                ),
+            ],
+        )
+
+    def test_nested_fields_become_dict(self, spec_with_nested_schema_field, tmp_path):
+        gen = ClientGenerator(spec_with_nested_schema_field)
+        package_dir = gen.generate(tmp_path)
+        source = (package_dir / "v1" / "schemas.py").read_text()
+        assert "ma.fields.Dict(" in source
+        assert "ma.fields.Nested(" not in source
+
+    def test_nested_fallback_is_valid_python(
+        self, spec_with_nested_schema_field, tmp_path
+    ):
+        gen = ClientGenerator(spec_with_nested_schema_field)
+        package_dir = gen.generate(tmp_path)
+        for py_file in package_dir.rglob("*.py"):
+            source = py_file.read_text()
+            ast.parse(source, filename=str(py_file))
+
+
+class TestListFieldInnerType:
+    """List schema fields get a default inner type (String)."""
+
+    @pytest.fixture()
+    def spec_with_list_schema_field(self):
+        schema = SchemaInfo(
+            name="TagsQuerySchema",
+            fields=[
+                SchemaFieldInfo(
+                    name="tags",
+                    field_type="List",
+                    metadata={"description": "Filter tags"},
+                ),
+            ],
+        )
+        return ClientSpec(
+            name="tagging",
+            endpoints=[
+                EndpointInfo(
+                    name="tags",
+                    path="/api/v1/tags",
+                    method="GET",
+                    querystring_schema=schema,
+                    parameters=[
+                        ParameterInfo(
+                            name="tags", location="querystring", type_hint="list"
+                        ),
+                    ],
+                ),
+            ],
+        )
+
+    def test_list_field_has_inner_type(self, spec_with_list_schema_field, tmp_path):
+        gen = ClientGenerator(spec_with_list_schema_field)
+        package_dir = gen.generate(tmp_path)
+        source = (package_dir / "v1" / "schemas.py").read_text()
+        assert "ma.fields.List(ma.fields.String()" in source
+
+    def test_list_field_is_valid_python(self, spec_with_list_schema_field, tmp_path):
+        gen = ClientGenerator(spec_with_list_schema_field)
+        package_dir = gen.generate(tmp_path)
+        for py_file in package_dir.rglob("*.py"):
+            source = py_file.read_text()
+            ast.parse(source, filename=str(py_file))

--- a/tests/test_introspection.py
+++ b/tests/test_introspection.py
@@ -178,11 +178,11 @@ class TestResolveBaseMarshmallowType:
     def test_standard_field_resolves_to_itself(self):
         assert _resolve_base_marshmallow_type(ma.fields.String) == "String"
 
-    def test_bare_field_subclass(self):
+    def test_bare_field_subclass_defaults_to_string(self):
         class RawCustom(ma.fields.Field):
             pass
 
-        assert _resolve_base_marshmallow_type(RawCustom) == "Field"
+        assert _resolve_base_marshmallow_type(RawCustom) == "String"
 
 
 class TestDetectCustomFields:


### PR DESCRIPTION
## Summary

- Fix two **import blockers**: `QueryStringList` extending `ma.fields.List` without an inner type, and `ma.fields.Nested()` called without a schema argument in generated schemas
- Fix two **validation issues**: custom fields extending bare `ma.fields.Field` now extend `ma.fields.String` for basic serialization
- Four template/logic changes: `fields.py.j2` (conditional `__init__` for List/Nested), `_field_kwargs_filter` (default inner type for List), both `schemas.py.j2` (Nested -> Dict fallback), `_resolve_base_marshmallow_type` (String instead of Field)

Closes #33

## Test plan

- [ ] Verify `TestCustomFieldListBaseType` passes: custom field with `base_type="List"` generates `__init__` with `ma.fields.String()` default
- [ ] Verify `TestCustomFieldNestedBaseType` passes: custom field with `base_type="Nested"` generates `__init__` with `ma.Schema` default
- [ ] Verify `TestNestedFieldFallback` passes: schema `Nested` fields render as `ma.fields.Dict(` not `ma.fields.Nested(`
- [ ] Verify `TestListFieldInnerType` passes: schema `List` fields render as `ma.fields.List(ma.fields.String(), ...)`
- [ ] Verify `test_bare_field_subclass_defaults_to_string` passes: MRO resolution returns `"String"` for bare `Field` subclasses
- [ ] All 494 tests pass with `make check`