### PR TITLE
Fix Enum field generation: fall back to String when enum class is unavailable

### DIFF
--- a/src/pyramid_client_builder/generator/python_templates/{{package_name}}/@each(versions)/schemas.py.j2
+++ b/src/pyramid_client_builder/generator/python_templates/{{package_name}}/@each(versions)/schemas.py.j2
@@ -20,6 +20,8 @@ class {{ schema.name }}(ma.Schema):
 {% for field in schema.fields %}
 {% if field.field_type == 'Nested' %}
     {{ field.name }} = ma.fields.Dict({{ field | field_kwargs }})
+{% elif field.field_type == 'Enum' %}
+    {{ field.name }} = ma.fields.String({{ field | field_kwargs }})
 {% elif field.field_type in custom_field_names %}
     {{ field.name }} = {{ field.field_type }}({{ field | field_kwargs }})
 {% else %}

--- a/src/pyramid_client_builder/generator/python_templates/{{package_name}}/schemas.py.j2
+++ b/src/pyramid_client_builder/generator/python_templates/{{package_name}}/schemas.py.j2
@@ -20,6 +20,8 @@ class {{ schema.name }}(ma.Schema):
 {% for field in schema.fields %}
 {% if field.field_type == 'Nested' %}
     {{ field.name }} = ma.fields.Dict({{ field | field_kwargs }})
+{% elif field.field_type == 'Enum' %}
+    {{ field.name }} = ma.fields.String({{ field | field_kwargs }})
 {% elif field.field_type in custom_field_names %}
     {{ field.name }} = {{ field.field_type }}({{ field | field_kwargs }})
 {% else %}

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -1484,3 +1484,56 @@ class TestListFieldInnerType:
         for py_file in package_dir.rglob("*.py"):
             source = py_file.read_text()
             ast.parse(source, filename=str(py_file))
+
+
+# ======================================================================
+# Schema fields: Enum -> String fallback
+# ======================================================================
+
+
+class TestEnumFieldFallback:
+    """Enum schema fields without an enum class fall back to String."""
+
+    @pytest.fixture()
+    def spec_with_enum_schema_field(self):
+        schema = SchemaInfo(
+            name="EntityResponseSchema",
+            fields=[
+                SchemaFieldInfo(name="name", field_type="String", required=True),
+                SchemaFieldInfo(
+                    name="origin",
+                    field_type="Enum",
+                    metadata={"description": "Entity origin"},
+                ),
+                SchemaFieldInfo(
+                    name="status",
+                    field_type="Enum",
+                    required=True,
+                ),
+            ],
+        )
+        return ClientSpec(
+            name="legal_entity",
+            endpoints=[
+                EndpointInfo(
+                    name="entities",
+                    path="/api/v1/entities",
+                    method="GET",
+                    response_schema=schema,
+                ),
+            ],
+        )
+
+    def test_enum_fields_become_string(self, spec_with_enum_schema_field, tmp_path):
+        gen = ClientGenerator(spec_with_enum_schema_field)
+        package_dir = gen.generate(tmp_path)
+        source = (package_dir / "v1" / "schemas.py").read_text()
+        assert "ma.fields.String(" in source
+        assert "ma.fields.Enum(" not in source
+
+    def test_enum_fallback_is_valid_python(self, spec_with_enum_schema_field, tmp_path):
+        gen = ClientGenerator(spec_with_enum_schema_field)
+        package_dir = gen.generate(tmp_path)
+        for py_file in package_dir.rglob("*.py"):
+            source = py_file.read_text()
+            ast.parse(source, filename=str(py_file))


### PR DESCRIPTION
## Summary

- `ma.fields.Enum()` was rendered without its required positional enum class argument, causing `TypeError` at import time
- Enum fields now fall back to `ma.fields.String()` in both root and versioned `schemas.py.j2` templates, matching the existing `Nested -> Dict` fallback pattern
- Added `TestEnumFieldFallback` test class with two tests (output assertion + valid Python check)

Closes #35

## Test plan

- [x] `make check` passes (504 tests, lint clean)
- [x] New tests verify `ma.fields.String(` appears and `ma.fields.Enum(` does not in generated output
- [x] New tests verify generated Python files parse without errors