### PR TITLE
Fix list endpoints deserializing paginated response as single object

### DIFF
--- a/src/pyramid_client_builder/generator/core.py
+++ b/src/pyramid_client_builder/generator/core.py
@@ -19,6 +19,7 @@ from pyramid_client_builder.generator.common import (
     rename_schemas,
 )
 from pyramid_client_builder.generator.naming import (
+    is_collection_endpoint,
     to_class_name,
     to_method_name,
     to_package_name,
@@ -133,7 +134,11 @@ class ClientGenerator:
     # ------------------------------------------------------------------
 
     def _annotate_endpoints(self, endpoints: list[EndpointInfo]) -> None:
-        """Add computed ``method_name`` attribute for template rendering."""
+        """Add computed attributes for template rendering.
+
+        Sets ``method_name`` (Python snake_case) and ``is_collection``
+        (True for list endpoints that return paginated responses).
+        """
         seen_names: dict[str, int] = {}
 
         for endpoint in endpoints:
@@ -143,6 +148,9 @@ class ClientGenerator:
 
             method_name = base_name if count == 0 else f"{base_name}_{count}"
             endpoint.method_name = method_name  # type: ignore[attr-defined]
+            endpoint.is_collection = is_collection_endpoint(  # type: ignore[attr-defined]
+                endpoint.name, endpoint.method, endpoint.path
+            )
 
     def _create_jinja_env(self) -> Environment:
         env = Environment(

--- a/src/pyramid_client_builder/generator/flutter_core.py
+++ b/src/pyramid_client_builder/generator/flutter_core.py
@@ -28,6 +28,7 @@ from pyramid_client_builder.generator.flutter_naming import (
     to_dart_version_field,
     to_dart_version_prefix,
 )
+from pyramid_client_builder.generator.naming import is_collection_endpoint
 from pyramid_client_builder.generator.renderer import render_tree
 from pyramid_client_builder.models import ClientSpec, EndpointInfo
 
@@ -118,7 +119,7 @@ class FlutterClientGenerator:
         return output_path
 
     def _annotate_endpoints(self, endpoints: list[EndpointInfo]) -> None:
-        """Add computed ``method_name`` attribute (camelCase Dart method)."""
+        """Add computed attributes (camelCase Dart method name + collection flag)."""
         seen_names: dict[str, int] = {}
 
         for endpoint in endpoints:
@@ -130,6 +131,9 @@ class FlutterClientGenerator:
 
             method_name = base_name if count == 0 else f"{base_name}{count}"
             endpoint.method_name = method_name  # type: ignore[attr-defined]
+            endpoint.is_collection = is_collection_endpoint(  # type: ignore[attr-defined]
+                endpoint.name, endpoint.method, endpoint.path
+            )
 
     def _create_jinja_env(self) -> Environment:
         env = Environment(
@@ -201,6 +205,8 @@ def _dart_method_params_filter(endpoint: EndpointInfo) -> str:
 def _dart_return_type_filter(endpoint: EndpointInfo) -> str:
     """Return the Dart return type for an endpoint method."""
     if endpoint.response_schema:
+        if getattr(endpoint, "is_collection", False):
+            return f"List<{endpoint.response_schema.name}>"
         return endpoint.response_schema.name
     return "Map<String, dynamic>"
 

--- a/src/pyramid_client_builder/generator/flutter_templates/lib/src/@each(versions)/client.dart.j2
+++ b/src/pyramid_client_builder/generator/flutter_templates/lib/src/@each(versions)/client.dart.j2
@@ -89,7 +89,12 @@ class {{ version_class }}Client {
     if (response.statusCode >= 400) {
       throw Exception('HTTP ${response.statusCode}: ${response.body}');
     }
-{% if endpoint.response_schema %}
+{% if endpoint.response_schema and endpoint.is_collection %}
+    final data = jsonDecode(response.body) as Map<String, dynamic>;
+    return (data['results'] as List<dynamic>)
+        .map((e) => {{ endpoint.response_schema.name }}.fromJson(e as Map<String, dynamic>))
+        .toList();
+{% elif endpoint.response_schema %}
     return {{ endpoint.response_schema.name }}.fromJson(
       jsonDecode(response.body) as Map<String, dynamic>,
     );

--- a/src/pyramid_client_builder/generator/flutter_templates/lib/src/client.dart.j2
+++ b/src/pyramid_client_builder/generator/flutter_templates/lib/src/client.dart.j2
@@ -104,7 +104,12 @@ class {{ class_name }} {
     if (response.statusCode >= 400) {
       throw Exception('HTTP ${response.statusCode}: ${response.body}');
     }
-{% if endpoint.response_schema %}
+{% if endpoint.response_schema and endpoint.is_collection %}
+    final data = jsonDecode(response.body) as Map<String, dynamic>;
+    return (data['results'] as List<dynamic>)
+        .map((e) => {{ endpoint.response_schema.name }}.fromJson(e as Map<String, dynamic>))
+        .toList();
+{% elif endpoint.response_schema %}
     return {{ endpoint.response_schema.name }}.fromJson(
       jsonDecode(response.body) as Map<String, dynamic>,
     );

--- a/src/pyramid_client_builder/generator/go_core.py
+++ b/src/pyramid_client_builder/generator/go_core.py
@@ -27,6 +27,7 @@ from pyramid_client_builder.generator.go_naming import (
     to_go_type,
     to_go_version_field,
 )
+from pyramid_client_builder.generator.naming import is_collection_endpoint
 from pyramid_client_builder.generator.renderer import render_tree
 from pyramid_client_builder.models import ClientSpec, EndpointInfo
 
@@ -121,7 +122,7 @@ class GoClientGenerator:
         return output_path
 
     def _annotate_endpoints(self, endpoints: list[EndpointInfo]) -> None:
-        """Add computed ``method_name`` attribute (PascalCase Go export)."""
+        """Add computed attributes (PascalCase Go export name + collection flag)."""
         seen_names: dict[str, int] = {}
 
         for endpoint in endpoints:
@@ -131,6 +132,9 @@ class GoClientGenerator:
 
             method_name = base_name if count == 0 else f"{base_name}{count}"
             endpoint.method_name = method_name  # type: ignore[attr-defined]
+            endpoint.is_collection = is_collection_endpoint(  # type: ignore[attr-defined]
+                endpoint.name, endpoint.method, endpoint.path
+            )
 
     def _create_jinja_env(self) -> Environment:
         env = Environment(
@@ -229,6 +233,8 @@ def _go_method_params_filter(endpoint: EndpointInfo) -> str:
 def _go_return_type_filter(endpoint: EndpointInfo) -> str:
     """Return the Go return type for an endpoint method."""
     if endpoint.response_schema:
+        if getattr(endpoint, "is_collection", False):
+            return f"[]{endpoint.response_schema.name}"
         return f"*{endpoint.response_schema.name}"
     return "map[string]interface{}"
 

--- a/src/pyramid_client_builder/generator/go_templates/@each(versions)/client.go.j2
+++ b/src/pyramid_client_builder/generator/go_templates/@each(versions)/client.go.j2
@@ -102,7 +102,15 @@ func (c *Client) {{ endpoint.method_name }}({{ endpoint | go_method_params }}) (
 		errBody, _ := io.ReadAll(resp.Body)
 		return {{ endpoint | go_zero_return }}, fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(errBody))
 	}
-{% if endpoint.response_schema %}
+{% if endpoint.response_schema and endpoint.is_collection %}
+	var envelope struct {
+		Results []{{ endpoint.response_schema.name }} `json:"results"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&envelope); err != nil {
+		return nil, fmt.Errorf("decode response: %w", err)
+	}
+	return envelope.Results, nil
+{% elif endpoint.response_schema %}
 	var result {{ endpoint.response_schema.name }}
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
 		return nil, fmt.Errorf("decode response: %w", err)

--- a/src/pyramid_client_builder/generator/go_templates/client.go.j2
+++ b/src/pyramid_client_builder/generator/go_templates/client.go.j2
@@ -137,7 +137,15 @@ func (c *Client) {{ endpoint.method_name }}({{ endpoint | go_method_params }}) (
 		errBody, _ := io.ReadAll(resp.Body)
 		return {{ endpoint | go_zero_return }}, fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(errBody))
 	}
-{% if endpoint.response_schema %}
+{% if endpoint.response_schema and endpoint.is_collection %}
+	var envelope struct {
+		Results []{{ endpoint.response_schema.name }} `json:"results"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&envelope); err != nil {
+		return nil, fmt.Errorf("decode response: %w", err)
+	}
+	return envelope.Results, nil
+{% elif endpoint.response_schema %}
 	var result {{ endpoint.response_schema.name }}
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
 		return nil, fmt.Errorf("decode response: %w", err)

--- a/src/pyramid_client_builder/generator/naming.py
+++ b/src/pyramid_client_builder/generator/naming.py
@@ -312,6 +312,17 @@ def _has_path_params(path: str) -> bool:
     return bool(_PATH_PARAM.search(path))
 
 
+def is_collection_endpoint(route_name: str, method: str, path: str) -> bool:
+    """Check if an endpoint is a collection (list) endpoint.
+
+    Returns True when ``to_method_name`` would produce a ``list_*`` name,
+    meaning the endpoint is a GET on a collection path with no path
+    parameters.  Used by generators to switch between single-object and
+    paginated-list response deserialization.
+    """
+    return to_method_name(route_name, method, path).startswith("list_")
+
+
 def _clean_route_name(route_name: str) -> str:
     """Clean a route name into a valid Python identifier fragment."""
     clean = _ROUTE_NAME_SEPS.sub("_", route_name).strip("_")

--- a/src/pyramid_client_builder/generator/python_templates/{{package_name}}/@each(versions)/client.py.j2
+++ b/src/pyramid_client_builder/generator/python_templates/{{package_name}}/@each(versions)/client.py.j2
@@ -76,7 +76,9 @@ class {{ version_class_name }}:
             timeout=self.timeout,
         )
         response.raise_for_status()
-{% if endpoint.response_schema %}
+{% if endpoint.response_schema and endpoint.is_collection %}
+        return {{ endpoint.response_schema.name }}(many=True).load(response.json()["results"])
+{% elif endpoint.response_schema %}
         return {{ endpoint.response_schema.name }}().load(response.json())
 {% else %}
         return response.json()

--- a/src/pyramid_client_builder/generator/python_templates/{{package_name}}/client.py.j2
+++ b/src/pyramid_client_builder/generator/python_templates/{{package_name}}/client.py.j2
@@ -86,7 +86,9 @@ class {{ class_name }}:
             timeout=self.timeout,
         )
         response.raise_for_status()
-{% if endpoint.response_schema %}
+{% if endpoint.response_schema and endpoint.is_collection %}
+        return {{ endpoint.response_schema.name }}(many=True).load(response.json()["results"])
+{% elif endpoint.response_schema %}
         return {{ endpoint.response_schema.name }}().load(response.json())
 {% else %}
         return response.json()

--- a/tests/test_flutter_generator.py
+++ b/tests/test_flutter_generator.py
@@ -595,10 +595,13 @@ class TestFlutterMethodSignatures:
             name="billing",
             endpoints=[
                 EndpointInfo(
-                    name="charges",
-                    path="/api/v1/charges",
+                    name="charge_detail",
+                    path="/api/v1/charges/{charge_id}",
                     method="GET",
                     response_schema=response_schema,
+                    parameters=[
+                        ParameterInfo(name="charge_id", location="path"),
+                    ],
                 ),
             ],
         )
@@ -612,6 +615,64 @@ class TestFlutterMethodSignatures:
         gen.generate(tmp_path)
         source = (tmp_path / "lib" / "src" / "v1" / "client.dart").read_text()
         assert "Future<Map<String, dynamic>>" in source
+
+
+# ======================================================================
+# Collection response deserialization (paginated list endpoints)
+# ======================================================================
+
+
+class TestFlutterCollectionResponseDeserialization:
+    """Verify list endpoints use List<T> return types and extract 'results'."""
+
+    @pytest.fixture()
+    def collection_spec(self):
+        schema = SchemaInfo(
+            name="PersonSchema",
+            fields=[
+                SchemaFieldInfo(name="id", field_type="String", required=True),
+                SchemaFieldInfo(name="name", field_type="String", required=True),
+            ],
+        )
+        return ClientSpec(
+            name="legal_entity",
+            endpoints=[
+                EndpointInfo(
+                    name="persons",
+                    path="/api/v1/persons",
+                    method="GET",
+                    response_schema=schema,
+                ),
+                EndpointInfo(
+                    name="person_detail",
+                    path="/api/v1/persons/{person_id}",
+                    method="GET",
+                    response_schema=schema,
+                    parameters=[
+                        ParameterInfo(name="person_id", location="path"),
+                    ],
+                ),
+            ],
+        )
+
+    def test_list_endpoint_returns_list_type(self, collection_spec, tmp_path):
+        gen = FlutterClientGenerator(collection_spec)
+        gen.generate(tmp_path)
+        source = (tmp_path / "lib" / "src" / "v1" / "client.dart").read_text()
+        assert "Future<List<PersonsResponseSchema>>" in source
+
+    def test_list_endpoint_extracts_results(self, collection_spec, tmp_path):
+        gen = FlutterClientGenerator(collection_spec)
+        gen.generate(tmp_path)
+        source = (tmp_path / "lib" / "src" / "v1" / "client.dart").read_text()
+        assert "data['results']" in source
+        assert "PersonsResponseSchema.fromJson" in source
+
+    def test_detail_endpoint_returns_single_model(self, collection_spec, tmp_path):
+        gen = FlutterClientGenerator(collection_spec)
+        gen.generate(tmp_path)
+        source = (tmp_path / "lib" / "src" / "v1" / "client.dart").read_text()
+        assert "Future<PersonsResponseSchema>" in source
 
 
 # ======================================================================

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -413,6 +413,92 @@ class TestPycornmarshGeneration:
 
 
 # ======================================================================
+# Collection response deserialization (paginated list endpoints)
+# ======================================================================
+
+
+class TestCollectionResponseDeserialization:
+    """Verify list endpoints use many=True and extract 'results' from response."""
+
+    @pytest.fixture()
+    def collection_spec(self):
+        schema = SchemaInfo(
+            name="PersonSchema",
+            fields=[
+                SchemaFieldInfo(name="id", field_type="String", required=True),
+                SchemaFieldInfo(name="name", field_type="String", required=True),
+            ],
+        )
+        return ClientSpec(
+            name="legal_entity",
+            endpoints=[
+                EndpointInfo(
+                    name="persons",
+                    path="/api/v1/persons",
+                    method="GET",
+                    response_schema=schema,
+                ),
+                EndpointInfo(
+                    name="person_detail",
+                    path="/api/v1/persons/{person_id}",
+                    method="GET",
+                    response_schema=schema,
+                    parameters=[
+                        ParameterInfo(name="person_id", location="path"),
+                    ],
+                ),
+            ],
+        )
+
+    def test_list_endpoint_uses_many_true(self, collection_spec, tmp_path):
+        gen = ClientGenerator(collection_spec)
+        package_dir = gen.generate(tmp_path)
+        v1_source = (package_dir / "v1" / "client.py").read_text()
+        assert (
+            'PersonsResponseSchema(many=True).load(response.json()["results"])'
+            in v1_source
+        )
+
+    def test_detail_endpoint_uses_single_load(self, collection_spec, tmp_path):
+        gen = ClientGenerator(collection_spec)
+        package_dir = gen.generate(tmp_path)
+        v1_source = (package_dir / "v1" / "client.py").read_text()
+        assert "PersonsResponseSchema().load(response.json())" in v1_source
+
+    def test_collection_generated_code_is_valid_python(self, collection_spec, tmp_path):
+        gen = ClientGenerator(collection_spec)
+        package_dir = gen.generate(tmp_path)
+        for py_file in package_dir.rglob("*.py"):
+            source = py_file.read_text()
+            ast.parse(source, filename=str(py_file))
+
+    def test_httpx_list_endpoint_uses_many_true(self, collection_spec, tmp_path):
+        gen = ClientGenerator(collection_spec, http_client="httpx")
+        package_dir = gen.generate(tmp_path)
+        v1_source = (package_dir / "v1" / "client.py").read_text()
+        assert (
+            'PersonsResponseSchema(many=True).load(response.json()["results"])'
+            in v1_source
+        )
+
+    def test_list_without_response_schema_returns_raw_json(self, tmp_path):
+        spec = ClientSpec(
+            name="test",
+            endpoints=[
+                EndpointInfo(
+                    name="items",
+                    path="/api/v1/items",
+                    method="GET",
+                ),
+            ],
+        )
+        gen = ClientGenerator(spec)
+        package_dir = gen.generate(tmp_path)
+        v1_source = (package_dir / "v1" / "client.py").read_text()
+        assert "return response.json()" in v1_source
+
+
+# ======================================================================
 # Method signatures
 # ======================================================================
 

--- a/tests/test_go_generator.py
+++ b/tests/test_go_generator.py
@@ -595,10 +595,13 @@ class TestGoMethodSignatures:
             name="billing",
             endpoints=[
                 EndpointInfo(
-                    name="charges",
-                    path="/api/v1/charges",
+                    name="charge_detail",
+                    path="/api/v1/charges/{charge_id}",
                     method="GET",
                     response_schema=response_schema,
+                    parameters=[
+                        ParameterInfo(name="charge_id", location="path"),
+                    ],
                 ),
             ],
         )
@@ -612,6 +615,64 @@ class TestGoMethodSignatures:
         gen.generate(tmp_path)
         source = (tmp_path / "v1" / "client.go").read_text()
         assert "(map[string]interface{}, error)" in source
+
+
+# ======================================================================
+# Collection response deserialization (paginated list endpoints)
+# ======================================================================
+
+
+class TestGoCollectionResponseDeserialization:
+    """Verify list endpoints use slice return types and decode from 'results'."""
+
+    @pytest.fixture()
+    def collection_spec(self):
+        schema = SchemaInfo(
+            name="PersonSchema",
+            fields=[
+                SchemaFieldInfo(name="id", field_type="String", required=True),
+                SchemaFieldInfo(name="name", field_type="String", required=True),
+            ],
+        )
+        return ClientSpec(
+            name="legal_entity",
+            endpoints=[
+                EndpointInfo(
+                    name="persons",
+                    path="/api/v1/persons",
+                    method="GET",
+                    response_schema=schema,
+                ),
+                EndpointInfo(
+                    name="person_detail",
+                    path="/api/v1/persons/{person_id}",
+                    method="GET",
+                    response_schema=schema,
+                    parameters=[
+                        ParameterInfo(name="person_id", location="path"),
+                    ],
+                ),
+            ],
+        )
+
+    def test_list_endpoint_returns_slice(self, collection_spec, tmp_path):
+        gen = GoClientGenerator(collection_spec)
+        gen.generate(tmp_path)
+        source = (tmp_path / "v1" / "client.go").read_text()
+        assert "([]PersonsResponseSchema, error)" in source
+
+    def test_list_endpoint_decodes_envelope(self, collection_spec, tmp_path):
+        gen = GoClientGenerator(collection_spec)
+        gen.generate(tmp_path)
+        source = (tmp_path / "v1" / "client.go").read_text()
+        assert '`json:"results"`' in source
+        assert "envelope.Results" in source
+
+    def test_detail_endpoint_returns_pointer(self, collection_spec, tmp_path):
+        gen = GoClientGenerator(collection_spec)
+        gen.generate(tmp_path)
+        source = (tmp_path / "v1" / "client.go").read_text()
+        assert "(*PersonsResponseSchema, error)" in source
 
 
 # ======================================================================

--- a/tests/test_naming.py
+++ b/tests/test_naming.py
@@ -5,6 +5,7 @@ import pytest
 from pyramid_client_builder.generator.naming import (
     _path_segments,
     extract_version,
+    is_collection_endpoint,
     needs_schema_rename,
     to_class_name,
     to_method_name,
@@ -306,6 +307,35 @@ class TestToMethodNameSingularization:
     def test_singularization_in_detail(self, route_name, method, path, expected_suffix):
         result = to_method_name(route_name, method, path)
         assert result == expected_suffix
+
+
+class TestIsCollectionEndpoint:
+    """Verify collection endpoint detection for paginated response handling."""
+
+    @pytest.mark.parametrize(
+        "route_name, method, path",
+        [
+            ("charges", "GET", "/api/v1/charges"),
+            ("invoices", "GET", "/api/v1/invoices"),
+            ("items", "GET", "/api/v1/items"),
+        ],
+    )
+    def test_collection_get_is_collection(self, route_name, method, path):
+        assert is_collection_endpoint(route_name, method, path) is True
+
+    @pytest.mark.parametrize(
+        "route_name, method, path",
+        [
+            ("charge_detail", "GET", "/api/v1/charges/{charge_id}"),
+            ("charges", "POST", "/api/v1/charges"),
+            ("charges", "DELETE", "/api/v1/charges/{charge_id}"),
+            ("charges", "PUT", "/api/v1/charges/{charge_id}"),
+            ("home", "GET", "/"),
+            ("health", "GET", "/health"),
+        ],
+    )
+    def test_non_collection_is_not_collection(self, route_name, method, path):
+        assert is_collection_endpoint(route_name, method, path) is False
 
 
 class TestWildcardPaths:


### PR DESCRIPTION
## Summary

- Add `is_collection_endpoint()` detection to `naming.py` that identifies collection endpoints (GET on collection paths producing `list_*` method names)
- Set `endpoint.is_collection` flag in all three generators (Python, Go, Flutter) during endpoint annotation
- Fix all 8 client templates (root + versioned for each variant) to extract the `"results"` array from paginated responses and deserialize items individually instead of treating the envelope as a single schema instance

Closes #37

## Test plan

- [x] `make check` passes (lint + 524 tests)
- [x] New `TestIsCollectionEndpoint` tests in `test_naming.py` verify collection detection for GET collections, detail endpoints, POST/DELETE/PUT, and non-API paths
- [x] New `TestCollectionResponseDeserialization` tests in `test_generator.py` verify Python generates `Schema(many=True).load(response.json()["results"])` for list endpoints and `Schema().load(response.json())` for detail endpoints (both requests and httpx backends)
- [x] New `TestGoCollectionResponseDeserialization` tests verify Go generates `[]Schema` return type and envelope decoding for list endpoints
- [x] New `TestFlutterCollectionResponseDeserialization` tests verify Flutter generates `List<Schema>` return type and results extraction for list endpoints
- [x] Existing tests for detail endpoints updated to use detail paths (with path parameters) to avoid false collection detection