### PR TITLE
Generated schemas reject unknown fields from server responses

### DIFF
--- a/knowledge/decisions.md
+++ b/knowledge/decisions.md
@@ -376,3 +376,15 @@ Use this format when adding a new decision:
 **Decision**: Add a structural guard to the verb-detection condition: `not _ends_with_param(path)`. The verb-action pattern (e.g., `/charges/{id}/cancel` → `cancel_charge`) always has the verb as the **last segment of the URL itself**, not just the last segment after stripping params. When the URL ends with a path parameter, the preceding segments are resource names — not verbs.
 
 **Consequences**: Resource names that are also English verbs are no longer misidentified as verb actions when they precede a path parameter. All existing verb-action patterns continue to work because their verbs are genuinely the last URL segment. The fix is a single added condition, using the existing `_ends_with_param` function.
+
+---
+
+### 2026-04-08 — Add Meta.unknown = INCLUDE to all generated schemas
+
+**Status**: Accepted (fixes "Generated schemas reject unknown fields from server responses")
+
+**Context**: Generated marshmallow schemas inherited the default `unknown = RAISE` behavior. When the server added new fields to API responses, the client's `schema.load()` call raised `ValidationError` for the unrecognized fields. This made clients brittle — any server-side addition broke existing clients even though the new fields were backward-compatible.
+
+**Decision**: Add `class Meta: unknown = ma.INCLUDE` to every generated schema class in both `schemas.py.j2` templates (top-level and versioned). The setting applies to all schemas, not just response schemas, because: (1) nested schemas inside responses also need it, (2) schemas can be shared across roles, (3) the template has no per-schema role info after deduplication in `collect_schemas`, and (4) `INCLUDE` has no adverse effect on request schemas using `dump()`. The `pass` statement for empty schemas (no fields) is no longer needed since `class Meta` provides a valid class body.
+
+**Consequences**: Generated clients tolerate unknown fields in API responses, making them forward-compatible with server-side additions. Unknown fields are preserved in the deserialized output (available via the dict). Empty schemas no longer emit `pass`.

--- a/src/pyramid_client_builder/generator/python_templates/{{package_name}}/@each(versions)/schemas.py.j2
+++ b/src/pyramid_client_builder/generator/python_templates/{{package_name}}/@each(versions)/schemas.py.j2
@@ -14,9 +14,10 @@ from {{ package_name }}.fields import (
 
 
 class {{ schema.name }}(ma.Schema):
-{% if not schema.fields %}
-    pass
-{% else %}
+    class Meta:
+        unknown = ma.INCLUDE
+{% if schema.fields %}
+
 {% for field in schema.fields %}
 {% if field.field_type == 'Nested' and field.many and field.nested_schema %}
     {{ field.name }} = ma.fields.List({{ field | field_kwargs }})

--- a/src/pyramid_client_builder/generator/python_templates/{{package_name}}/schemas.py.j2
+++ b/src/pyramid_client_builder/generator/python_templates/{{package_name}}/schemas.py.j2
@@ -14,9 +14,10 @@ from {{ package_name }}.fields import (
 
 
 class {{ schema.name }}(ma.Schema):
-{% if not schema.fields %}
-    pass
-{% else %}
+    class Meta:
+        unknown = ma.INCLUDE
+{% if schema.fields %}
+
 {% for field in schema.fields %}
 {% if field.field_type == 'Nested' and field.many and field.nested_schema %}
     {{ field.name }} = ma.fields.List({{ field | field_kwargs }})

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -315,12 +315,12 @@ class TestClientGeneratorWithExampleApp:
         package_dir = gen.generate(tmp_path)
         assert not (package_dir / "schemas.py").exists()
 
-    def test_empty_schema_generates_pass(self, example_spec, tmp_path):
+    def test_empty_schema_has_only_meta(self, example_spec, tmp_path):
         gen = ClientGenerator(example_spec)
         package_dir = gen.generate(tmp_path)
         source = (package_dir / "v1" / "schemas.py").read_text()
         assert "class DocumentConciliateRequestSchema(ma.Schema):" in source
-        assert "    pass" in source
+        assert "    pass" not in source
 
     def test_composite_schema_generates_inner_schemas(self, example_spec, tmp_path):
         gen = ClientGenerator(example_spec)
@@ -757,14 +757,14 @@ class TestSchemaRenaming:
 
 
 # ======================================================================
-# Empty schemas (no fields → must emit ``pass``)
+# Empty schemas (no fields → class body is just Meta)
 # ======================================================================
 
 
-class TestEmptySchemaGeneratesPass:
-    """A schema with no fields must produce ``pass`` so the class body is valid."""
+class TestEmptySchemaBody:
+    """A schema with no fields still has a valid body thanks to class Meta."""
 
-    def test_empty_schema_contains_pass(self, tmp_path):
+    def test_empty_schema_has_meta(self, tmp_path):
         schema = SchemaInfo(name="EmptyRequestSchema")
         spec = ClientSpec(
             name="test",
@@ -781,7 +781,8 @@ class TestEmptySchemaGeneratesPass:
         package_dir = gen.generate(tmp_path)
         source = (package_dir / "v1" / "schemas.py").read_text()
         assert "class EmptyRequestSchema(ma.Schema):" in source
-        assert "    pass" in source
+        assert "class Meta:" in source
+        assert "unknown = ma.INCLUDE" in source
 
     def test_empty_schema_is_valid_python(self, tmp_path):
         schema = SchemaInfo(name="EmptyRequestSchema")
@@ -824,7 +825,6 @@ class TestEmptySchemaGeneratesPass:
         package_dir = gen.generate(tmp_path)
         source = (package_dir / "v1" / "schemas.py").read_text()
         assert "class EmptyRequestSchema(ma.Schema):" in source
-        assert "    pass" in source
         assert "class ThingsResponseSchema(ma.Schema):" in source
         assert "id = ma.fields.String()" in source
         ast.parse(source, filename="schemas.py")
@@ -2068,3 +2068,124 @@ class TestEnumFieldFallback:
         for py_file in package_dir.rglob("*.py"):
             source = py_file.read_text()
             ast.parse(source, filename=str(py_file))
+
+
+# ======================================================================
+# Unknown fields tolerance (Meta.unknown = INCLUDE)
+# ======================================================================
+
+
+class TestSchemasIncludeUnknownFields:
+    """Generated schemas must set Meta.unknown = ma.INCLUDE.
+
+    Marshmallow defaults to RAISE for unknown fields, which breaks
+    clients when the server adds new response fields over time.
+    """
+
+    def test_response_schema_has_meta_unknown_include(self, tmp_path):
+        schema = SchemaInfo(
+            name="OperatorResponseSchema",
+            fields=[
+                SchemaFieldInfo(name="id", field_type="Integer"),
+                SchemaFieldInfo(name="name", field_type="String"),
+            ],
+        )
+        spec = ClientSpec(
+            name="legal_entity",
+            endpoints=[
+                EndpointInfo(
+                    name="operators",
+                    path="/api/v1/operators",
+                    method="GET",
+                    response_schema=schema,
+                ),
+            ],
+        )
+        gen = ClientGenerator(spec)
+        package_dir = gen.generate(tmp_path)
+        source = (package_dir / "v1" / "schemas.py").read_text()
+        assert "class Meta:" in source
+        assert "unknown = ma.INCLUDE" in source
+
+    def test_empty_schema_has_meta_unknown_include(self, tmp_path):
+        schema = SchemaInfo(name="EmptyResponseSchema")
+        spec = ClientSpec(
+            name="test",
+            endpoints=[
+                EndpointInfo(
+                    name="things",
+                    path="/api/v1/things",
+                    method="GET",
+                    response_schema=schema,
+                ),
+            ],
+        )
+        gen = ClientGenerator(spec)
+        package_dir = gen.generate(tmp_path)
+        source = (package_dir / "v1" / "schemas.py").read_text()
+        assert "class Meta:" in source
+        assert "unknown = ma.INCLUDE" in source
+
+    def test_nested_schema_has_meta_unknown_include(self, tmp_path):
+        phone_schema = SchemaInfo(
+            name="PhoneSchema",
+            fields=[SchemaFieldInfo(name="number", field_type="String")],
+        )
+        person_schema = SchemaInfo(
+            name="PersonResponseSchema",
+            fields=[
+                SchemaFieldInfo(
+                    name="phone",
+                    field_type="Nested",
+                    nested_schema="PhoneSchema",
+                ),
+            ],
+            nested_schemas=[phone_schema],
+        )
+        spec = ClientSpec(
+            name="contacts",
+            endpoints=[
+                EndpointInfo(
+                    name="people",
+                    path="/api/v1/people",
+                    method="GET",
+                    response_schema=person_schema,
+                ),
+            ],
+        )
+        gen = ClientGenerator(spec)
+        package_dir = gen.generate(tmp_path)
+        source = (package_dir / "v1" / "schemas.py").read_text()
+        assert source.count("class Meta:") == 2
+        assert source.count("unknown = ma.INCLUDE") == 2
+
+    def test_schema_with_meta_unknown_is_valid_python(self, tmp_path):
+        schema = SchemaInfo(
+            name="WidgetResponseSchema",
+            fields=[SchemaFieldInfo(name="id", field_type="Integer")],
+        )
+        spec = ClientSpec(
+            name="widgets",
+            endpoints=[
+                EndpointInfo(
+                    name="widgets",
+                    path="/api/v1/widgets",
+                    method="GET",
+                    response_schema=schema,
+                ),
+            ],
+        )
+        gen = ClientGenerator(spec)
+        package_dir = gen.generate(tmp_path)
+        for py_file in package_dir.rglob("*.py"):
+            source = py_file.read_text()
+            ast.parse(source, filename=str(py_file))
+
+    def test_example_app_schemas_include_unknown(self, example_spec, tmp_path):
+        gen = ClientGenerator(example_spec)
+        package_dir = gen.generate(tmp_path)
+        source = (package_dir / "v1" / "schemas.py").read_text()
+        schema_count = source.count("(ma.Schema):")
+        meta_count = source.count("unknown = ma.INCLUDE")
+        assert schema_count > 0
+        assert meta_count == schema_count


### PR DESCRIPTION
## Summary

- Add `class Meta: unknown = ma.INCLUDE` to all generated marshmallow schema classes in both `schemas.py.j2` templates (top-level and versioned)
- Empty schemas no longer emit `pass` since `class Meta` provides a valid class body
- Add 5 new tests covering response schemas, empty schemas, nested schemas, valid-python validation, and the full example app

Closes #45

## Test plan

- [x] New `TestSchemasIncludeUnknownFields` test class with 5 tests verifying `class Meta: unknown = ma.INCLUDE` appears in every generated schema
- [x] Updated `TestEmptySchemaBody` (renamed from `TestEmptySchemaGeneratesPass`) to reflect new empty schema behavior
- [x] All 562 tests pass, ruff + black clean (`make check` green)